### PR TITLE
parseQuery parses boolean values as boolean

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,11 @@ function encodeBufferToBase(buffer, base, length) {
 }
 
 exports.parseQuery = function parseQuery(query) {
+	var specialValues = {
+		'null': null,
+		'true': true,
+		'false': false
+	};
 	if(!query) return {};
 	if(typeof query !== "string")
 		throw new Error("parseQuery should get a string as first argument");
@@ -55,6 +60,9 @@ exports.parseQuery = function parseQuery(query) {
 		if(idx >= 0) {
 			var name = arg.substr(0, idx);
 			var value = decodeURIComponent(arg.substr(idx+1));
+			if (specialValues[value] !== undefined) {
+				value = specialValues[value];
+			}
 			if(name.substr(-2) === "[]") {
 				name = decodeURIComponent(name.substr(0, name.length-2));
 				if(!Array.isArray(result[name]))

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ exports.parseQuery = function parseQuery(query) {
 		if(idx >= 0) {
 			var name = arg.substr(0, idx);
 			var value = decodeURIComponent(arg.substr(idx+1));
-			if (specialValues[value] !== undefined) {
+			if (specialValues.hasOwnProperty(value)) {
 				value = specialValues[value];
 			}
 			if(name.substr(-2) === "[]") {

--- a/test/index.js
+++ b/test/index.js
@@ -59,4 +59,18 @@ describe("loader-utils", function() {
 			});
 		});
 	});
+
+	describe("#parseQuery", function() {
+		[
+			[
+				"?sweet=true&name=cheesecake&slices=8&delicious&warm=false",
+				{"sweet":true,"name":"cheesecake","slices":"8","delicious":true,"warm": false}
+			]
+		].forEach(function(test) {
+			it("should parse " + test[0], function() {
+				var parsed = loaderUtils.parseQuery(test[0]);
+				assert.deepEqual(parsed, test[1]);
+			});
+		});
+	});
 });


### PR DESCRIPTION
Right now `parseQuery('?value=true')` returns strings instead of booleans: `{value: "true"}`.

This pull request fixes this and parses the strings "true", "false" and "null" correctly into their js counterparts.
It also provides tests for parseQuery.