### PR TITLE
Add folder token option to interpolateName

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The following tokens are replaced in the `name` parameter:
 * `[ext]` the extension of the resource
 * `[name]` the basename of the resource
 * `[path]` the path of the resource relative to the `context` query parameter or option.
+* `[folder]` the name of the folder in which the resource is located
 * `[hash]` the hash of `options.content` (Buffer) (by default it's the hex digest of the md5 hash)
 * `[<hashType>:hash:<digestType>:<length>]` optionally one can configure
   * other `hashType`s, i. e. `sha1`, `md5`, `sha256`, `sha512`

--- a/index.js
+++ b/index.js
@@ -196,12 +196,14 @@ exports.interpolateName = function interpolateName(loaderContext, name, options)
 	var ext = "bin";
 	var basename = "file";
 	var directory = "";
+	var ctxFolder = "";
 	if(loaderContext.resourcePath) {
 		var resourcePath = loaderContext.resourcePath;
 		var idx = resourcePath.lastIndexOf(".");
 		var i = resourcePath.lastIndexOf("\\");
 		var j = resourcePath.lastIndexOf("/");
 		var p = i < 0 ? j : j < 0 ? i : i < j ? i : j;
+		var folders;
 		if(idx >= 0) {
 			ext = resourcePath.substr(idx+1);
 			resourcePath = resourcePath.substr(0, idx);
@@ -213,11 +215,18 @@ exports.interpolateName = function interpolateName(loaderContext, name, options)
 		if (typeof context !== 'undefined') {
 			directory = path.relative(context, resourcePath + "_").replace(/\\/g, "/").replace(/\.\.(\/)?/g, "_$1");
 			directory = directory.substr(0, directory.length-1);
+			folders = directory.split('/');
+			ctxFolder = folders[folders.length - 2];
 		}
 		else {
 			directory = resourcePath.replace(/\\/g, "/").replace(/\.\.(\/)?/g, "_$1");
+			folders =  directory.split('/');
+			ctxFolder = folders[folders.length - 2];
 		}
-		if(directory.length === 1) directory = "";
+		if(directory.length === 1) {
+			directory = "";
+			ctxFolder = "";
+		}
 	}
 	var url = filename;
 	if(content) {
@@ -232,6 +241,8 @@ exports.interpolateName = function interpolateName(loaderContext, name, options)
 		return basename;
 	}).replace(/\[path\]/ig, function() {
 		return directory;
+	}).replace(/\[folder\]/ig, function() {
+		return ctxFolder;
 	});
 	if(regExp && loaderContext.resourcePath) {
 		var re = new RegExp(regExp);


### PR DESCRIPTION
Adding this to allow the ability for css-loader to name local modules based on their parent directory name, rather than filename (or full path).

See this issue for use case: https://github.com/webpack/css-loader/issues/70