### PR TITLE
url with chrome-extension protocol isn't treated as request

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ exports.isUrlRequest = function(url, root) {
 	// 1. it's a Data Url
 	// 2. it's an absolute url or and protocol-relative
 	// 3. it's some kind of url for a template
-	if(/^data:|^(https?:)?\/\/|^[\{\}\[\]#*;,'§\$%&\(=?`´\^°<>]/.test(url)) return false;
+	if(/^data:|^chrome-extension:|^(https?:)?\/\/|^[\{\}\[\]#*;,'§\$%&\(=?`´\^°<>]/.test(url)) return false;
 	// 4. It's also not an request if root isn't set and it's a root-relative url
 	if((root === undefined || root === false) && /^\//.test(url)) return false;
 	return true;


### PR DESCRIPTION
url with *chrome-extension* protocol shouldn't be treated as request.
Currently, if you have CSS code like this:
```css
#el {
    background-image: url('chrome-extension://hsjfhsjdhf/img/img.png');
}
```
*chrome-extension* will be treated as file or directly, and next error appears:
```
ERROR in ./~/css-loader!./~/less-loader!./less/content.less
    Module not found: Error: Cannot resolve 'file' or 'directory' ./chrome-extension://hsjfhsjdhf/img/img.png in /Project/less
     @ ./~/css-loader!./~/less-loader!./less/content.less 6:781-865
```