### PR TITLE
Fix stringifyRequest in windows when context and request is not in the same driver

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,8 +88,14 @@ exports.stringifyRequest = function(loaderContext, request) {
 	var splitted = request.split("!");
 	var context = loaderContext.context || (loaderContext.options && loaderContext.options.context);
 	return JSON.stringify(splitted.map(function(part) {
-		if(/^\/|^[A-Z]:/i.test(part) && context)
-			return "./" + path.relative(context, part).replace(/\\/g, "/");
+		if(/^\/|^[A-Z]:/i.test(part) && context) {
+			part = path.relative(context, part);
+			if(/^[A-Z]:/i.test(part)) {
+				return part;
+			} else {
+				return "./" + part.replace(/\\/g, "/");
+			}
+		}
 		return part;
 	}).join("!"));
 };


### PR DESCRIPTION

For example:

```
var context = 'C:\foo';
var request = 'E:\bar';

path.relative(context, request);  // -> E:\bar
"./" + path.relative(context, part); // -> ./E:\bar, And this file path is not found
```
