### PR TITLE
Incorrect start index for loop of the "match" variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -243,7 +243,7 @@ exports.interpolateName = function interpolateName(loaderContext, name, options)
 		var re = new RegExp(regExp);
 		var match = loaderContext.resourcePath.match(regExp);
 		if(match) {
-			for (var i = 1; i < match.length; i++) {
+			for (var i = 0; i < match.length; i++) {
 				var re = new RegExp("\\[" + i + "\\]", "ig");
 				url = url.replace(re, match[i]);
 			}


### PR DESCRIPTION
When you process a string by the `match()` method in the `loaderContext.resourcePath.match(regExp)` it returns an array there the matched result starts with the index = 0.

For example here is my match for this regular expression `[^\\]+(?=\\index\.js)`
`[ 'main-page',
  index: 51,
  input: 'C:\\Projects\\Work\\FPB\\PayBox\\frontend\\modules\\pages\\main-page\\index.js' ]

Based on the written above, the loop `for (var i = 1; i < match.length; i++) { ...}` should have start index 0, not 1.

This thing in documentation returns `[1]` as filename, but not the matched.
`// loaderContext.resourcePath = "/app/js/page-home.js"`
`loaderUtils.interpolateName(loaderContext, "script-[1].[ext]", { regExp: "page-(.*)\\.js", content: ... });`
`// => script-home.js`
