### PR TITLE
Feature/get loader config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cheesecakeLoader: {
 }
 ```
 
-It is recommended that you use your camelCased npm name as your default config property name.
+It is recommended that you use the camelCased loader name as your default config property name.
 
 ### `parseQuery`
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,35 @@
 
 ## Methods
 
+### `getLoaderConfig`
+
+Recommended way to retrieve the loader config:
+
+```javascript
+// inside your loader
+config = loaderUtils.getLoaderConfig(this, "myLoader");
+```
+
+Tries to read the loader config from the `webpack.config.js` under the given property name (`"myLoader"` in this case) and merges the result with the loader query. For example, if your `webpack.config.js` had this property...
+
+```javascript
+cheesecakeLoader: {
+	type: "delicious",
+	slices: 4
+}
+```
+
+...and your loader was called with `?slices=8`, `getLoaderConfig(this, "cheesecakeLoader")` would return
+
+```javascript
+{
+	type: "delicious",
+	slices: 8
+}
+```
+
+It is recommended that you use your camelCased npm name as your default config property name.
+
 ### `parseQuery`
 
 ``` javascript

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var JSON5 = require("json5");
 var path = require("path");
+var assign = require("object-assign");
 
 var baseEncodeTables = {
 	26: "abcdefghijklmnopqrstuvwxyz",
@@ -82,6 +83,19 @@ exports.parseQuery = function parseQuery(query) {
 		}
 	});
 	return result;
+};
+
+exports.getLoaderConfig = function(loaderContext, defaultConfigKey) {
+	if (!defaultConfigKey) {
+		throw new Error("Default config key missing");
+	}
+	var query = exports.parseQuery(loaderContext.query);
+	var configKey = query.config || defaultConfigKey;
+	var config = loaderContext.options[configKey] || {};
+
+	delete query.config;
+
+	return assign({}, config, query);
 };
 
 exports.stringifyRequest = function(loaderContext, request) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "utils for webpack loaders",
   "dependencies": {
     "big.js": "^3.0.2",
-    "json5": "^0.4.0"
+    "json5": "^0.4.0",
+    "object-assign": "^4.0.1"
   },
   "scripts": {
     "test": "mocha",

--- a/test/index.js
+++ b/test/index.js
@@ -88,7 +88,7 @@ describe("loader-utils", function() {
 			assert.deepEqual(config, {slices:8});
 		});
 		it("should throw an error if the default config key is missing", function () {
-		    assert.throws(function () {
+			assert.throws(function () {
 				loaderUtils.getLoaderConfig({});
 			}, "Default config key missing")
 		});

--- a/test/index.js
+++ b/test/index.js
@@ -74,6 +74,26 @@ describe("loader-utils", function() {
 		});
 	});
 
+	describe("#getLoaderConfig", function() {
+		it("should merge loaderContext.query and loaderContext.options.testLoader", function () {
+			var config = loaderUtils.getLoaderConfig({query:"?name=cheesecake",options:{testLoader:{slices:8}}}, "testLoader");
+			assert.deepEqual(config, {name:"cheesecake",slices:8});
+		});
+		it("should allow to specify a config property name via loaderContext.query.config", function () {
+			var config = loaderUtils.getLoaderConfig({query:"?name=cheesecake&config=otherConfig",options:{otherConfig:{slices:8}}}, "testLoader");
+			assert.deepEqual(config, {name:"cheesecake",slices:8});
+		});
+		it("should prefer loaderContext.query.slices over loaderContext.options.slices", function () {
+			var config = loaderUtils.getLoaderConfig({query:"?slices=8",options:{testLoader:{slices:4}}}, "testLoader");
+			assert.deepEqual(config, {slices:8});
+		});
+		it("should throw an error if the default config key is missing", function () {
+		    assert.throws(function () {
+				loaderUtils.getLoaderConfig({});
+			}, "Default config key missing")
+		});
+	});
+
 	describe("#getHashDigest", function() {
 		[
 			["test string", "md5", "hex", undefined, "6f8db599de986fab7a21625b7916589c"],


### PR DESCRIPTION
Currently, there are several loaders (less-loader, sass-loader, html-loader, markdown-loader) that accept "programmable" options like functions, regexes, etc. that are hard/impossible to stringify.

The `getLoaderConfig` unifies the way how configs are provided to loaders by first trying to read the options from the `webpack.config.js` under the given property key. After that, query options are merged into the object.

`getLoaderConfig` is described as *the recommended way to retrieve the config* in the README. After maintaining several loaders, I think we should encourage the users to put their loader configs on the `webpack.config.js`. Do you agree? @webpack/collab-team @sokra @webpack/html-loader-team 

Please give feedback before merging this in.