### PR TITLE
Add emoji digestType to getHashDigest

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The following tokens are replaced in the `name` parameter:
 * `[hash]` the hash of `options.content` (Buffer) (by default it's the hex digest of the md5 hash)
 * `[<hashType>:hash:<digestType>:<length>]` optionally one can configure
   * other `hashType`s, i. e. `sha1`, `md5`, `sha256`, `sha512`
-  * other `digestType`s, i. e. `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`
+  * other `digestType`s, i. e. `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`, `emoji`
   * and `length` the length in chars
 * `[N]` the N-th match obtained from matching the current file name against `options.regExp`
 
@@ -126,6 +126,10 @@ loaderUtils.interpolateName(loaderContext, "[path][name].[ext]?[hash]", { conten
 // loaderContext.resourcePath = "/app/js/page-home.js"
 loaderUtils.interpolateName(loaderContext, "script-[1].[ext]", { regExp: "page-(.*)\\.js", content: ... });
 // => script-home.js
+
+// loaderContext.resourcePath = "/app/style.css"
+loaderUtils.interpolateName(loaderContext, "[sha512:hash:emoji:4].[ext]", { content: ... });
+// => 💢🐩🎄⛅️.css
 ```
 
 ### `getHashDigest`
@@ -136,7 +140,7 @@ var digestString = loaderUtils.getHashDigest(buffer, hashType, digestType, maxLe
 
 * `buffer` the content that should be hashed
 * `hashType` one of `sha1`, `md5`, `sha256`, `sha512` or any other node.js supported hash type
-* `digestType` one of `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`
+* `digestType` one of `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`, `emoji`
 * `maxLength` the maximum length in chars
 
 ## License

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var JSON5 = require("json5");
 var path = require("path");
+var baseEmoji = require("base-emoji");
 
 var baseEncodeTables = {
 	26: "abcdefghijklmnopqrstuvwxyz",
@@ -189,6 +190,8 @@ exports.getHashDigest = function getHashDigest(buffer, hashType, digestType, max
 	    digestType === "base49" || digestType === "base52" || digestType === "base58" ||
 	    digestType === "base62" || digestType === "base64") {
 		return encodeBufferToBase(hash.digest(), digestType.substr(4), maxLength).substr(0, maxLength);
+	} else if (digestType === "emoji") {
+		return baseEmoji.toUnicode(hash.digest()).substr(0, maxLength * 2);
 	} else {
 		return hash.digest(digestType || "hex").substr(0, maxLength);
 	}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "utils for webpack loaders",
   "dependencies": {
+    "base-emoji": "2.0.1",
     "big.js": "^3.0.2",
     "json5": "^0.4.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -45,6 +45,17 @@ describe("loader-utils", function() {
 		});
 	});
 
+	describe("#interpolateName", function() {
+		[
+			["/app/style.css", "[sha512:hash:emoji:4].[ext]", "test content", "💢🐩🎄⛅️.css"]
+		].forEach(function(test) {
+			it("should interpolate " + test[0] + " " + test[1], function() {
+				var interpolatedName = loaderUtils.interpolateName({ resourcePath: test[0] }, test[1], { content: test[2] });
+				assert.equal(interpolatedName, test[3]);
+			});
+		});
+	});
+
 	describe("#parseString", function() {
 		[
 			["test string", "test string"],
@@ -82,7 +93,10 @@ describe("loader-utils", function() {
 			["test string", "md5", "base52", undefined, "dJnldHSAutqUacjgfBQGLQx"],
 			["test string", "md5", "base26", 6, "bhtsgu"],
 			["test string", "sha512", "base64", undefined, "2IS-kbfIPnVflXb9CzgoNESGCkvkb0urMmucPD9z8q6HuYz8RShY1-tzSUpm5-Ivx_u4H1MEzPgAhyhaZ7RKog"],
-			["test_string", "md5", "hex", undefined, "3474851a3410906697ec77337df7aae4"]
+			["test_string", "md5", "hex", undefined, "3474851a3410906697ec77337df7aae4"],
+			["test string", "md5", "emoji", undefined, "🔦🐨🐖💰❄️🔬🔦👐🌐🐻💫🔮🎁👶🐄🐁"],
+			["test string", "md5", "emoji", 16, "🔦🐨🐖💰❄️🔬🔦👐🌐🐻💫🔮🎁👶🐄🐁"],
+			["test string", "md5", "emoji", 8, "🔦🐨🐖💰❄️🔬🔦👐"]
 		].forEach(function(test) {
 			it("should getHashDigest " + test[0] + " " + test[1] + " " + test[2] + " " + test[3], function() {
 				var hashDigest = loaderUtils.getHashDigest(test[0], test[1], test[2], test[3]);


### PR DESCRIPTION
Added "emoji" as a digest type for getHashDigest(). While this will probably be useless for naming files it will be very useful for [css-loader](https://github.com/webpack/css-loader) since it uses interpolateName() to name CSS classes. It is a lot easier to figure out what's going on when emojis are used instead of random characters.