### PR TITLE
Add [emoji] token substitution to `interpolateName`

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ The following tokens are replaced in the `name` parameter:
 * `[ext]` the extension of the resource
 * `[name]` the basename of the resource
 * `[path]` the path of the resource relative to the `context` query parameter or option.
+* `[emoji]` a random emoji representation of `options.content`
+* `[emoji:<length>]` same as above, but with a customizable number of emojis
 * `[hash]` the hash of `options.content` (Buffer) (by default it's the hex digest of the md5 hash)
 * `[<hashType>:hash:<digestType>:<length>]` optionally one can configure
   * other `hashType`s, i. e. `sha1`, `md5`, `sha256`, `sha512`
@@ -108,6 +110,14 @@ loaderUtils.interpolateName(loaderContext, "html-[hash:6].html", { content: ... 
 // loaderContext.resourcePath = "/app/flash.txt"
 loaderUtils.interpolateName(loaderContext, "[hash]", { content: ... });
 // => c31e9820c001c9c4a86bce33ce43b679
+
+// loaderContext.resourcePath = "/app/img/image.gif"
+loaderUtils.interpolateName(loaderContext, "[emoji]", { content: ... });
+// => 👍
+
+// loaderContext.resourcePath = "/app/img/image.gif"
+loaderUtils.interpolateName(loaderContext, "[emoji:4]", { content: ... });
+// => 🙍🏢📤🐝
 
 // loaderContext.resourcePath = "/app/img/image.png"
 loaderUtils.interpolateName(loaderContext, "[sha512:hash:base64:7]", { content: ... });

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var baseEncodeTables = {
 
 function encodeBufferToBase(buffer, base, length) {
 	var encodeTable = baseEncodeTables[base];
-	if (!encodeTable) throw new Error("Enknown encoding base" + base);
+	if (!encodeTable) throw new Error("Unknown encoding base" + base);
 
 	var readLength = buffer.length;
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var baseEncodeTables = {
 	64: "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_"
 };
 
-function encodeBufferToBase(buffer, base, length) {
+function encodeBufferToBase(buffer, base) {
 	var encodeTable = baseEncodeTables[base];
 	if (!encodeTable) throw new Error("Unknown encoding base" + base);
 
@@ -188,7 +188,7 @@ exports.getHashDigest = function getHashDigest(buffer, hashType, digestType, max
 	if (digestType === "base26" || digestType === "base32" || digestType === "base36" ||
 	    digestType === "base49" || digestType === "base52" || digestType === "base58" ||
 	    digestType === "base62" || digestType === "base64") {
-		return encodeBufferToBase(hash.digest(), digestType.substr(4), maxLength).substr(0, maxLength);
+		return encodeBufferToBase(hash.digest(), digestType.substr(4)).substr(0, maxLength);
 	} else {
 		return hash.digest(digestType || "hex").substr(0, maxLength);
 	}

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var JSON5 = require("json5");
 var path = require("path");
+var emojiList = require("emojis-list");
 
 var baseEncodeTables = {
 	26: "abcdefghijklmnopqrstuvwxyz",
@@ -11,6 +12,21 @@ var baseEncodeTables = {
 	62: "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
 	64: "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_"
 };
+var emojiCache = {};
+
+function encodeStringToEmoji(content, length) {
+	if (emojiCache[content]) return emojiCache[content];
+	length = length || 1;
+	var emojis = [];
+	do {
+		var index = Math.floor(Math.random() * emojiList.length);
+		emojis.push(emojiList[index]);
+		emojiList.splice(index, 1);
+	} while (--length > 0);
+	var emojiEncoding = emojis.join('');
+	emojiCache[content] = emojiEncoding;
+	return emojiEncoding;
+}
 
 function encodeBufferToBase(buffer, base) {
 	var encodeTable = baseEncodeTables[base];
@@ -230,6 +246,8 @@ exports.interpolateName = function interpolateName(loaderContext, name, options)
 		// Match hash template
 		url = url.replace(/\[(?:(\w+):)?hash(?::([a-z]+\d*))?(?::(\d+))?\]/ig, function() {
 			return exports.getHashDigest(content, arguments[1], arguments[2], parseInt(arguments[3], 10));
+		}).replace(/\[emoji(?::(\d+))?\]/ig, function() {
+			return encodeStringToEmoji(content, arguments[1]);
 		});
 	}
 	url = url.replace(/\[ext\]/ig, function() {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 var JSON5 = require("json5");
 var path = require("path");
-var emojiList = require("emojis-list");
+var emojiRegex = /[\uD800-\uDFFF]./;
+var emojiList = require("emojis-list").filter(function(emoji) {
+	return emojiRegex.test(emoji)
+});
 
 var baseEncodeTables = {
 	26: "abcdefghijklmnopqrstuvwxyz",

--- a/index.js
+++ b/index.js
@@ -183,7 +183,7 @@ exports.parseString = function parseString(str) {
 exports.getHashDigest = function getHashDigest(buffer, hashType, digestType, maxLength) {
 	hashType = hashType || "md5";
 	maxLength = maxLength || 9999;
-	var hash = new (require("crypto").Hash)(hashType);
+	var hash = require("crypto").createHash(hashType);
 	hash.update(buffer);
 	if (digestType === "base26" || digestType === "base32" || digestType === "base36" ||
 	    digestType === "base49" || digestType === "base52" || digestType === "base58" ||

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "utils for webpack loaders",
   "dependencies": {
     "big.js": "^3.0.2",
+    "emojis-list": "^1.0.0",
     "json5": "^0.4.0"
   },
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -119,16 +119,15 @@ describe("loader-utils", function() {
 			[
 				[{}, "[emoji]", { content: "test" }],
 				function(result) {
-					assert.ok(emojiRegex.test(result));
+					assert.ok(emojiRegex.test(result), result);
 				},
 				"should interpolate [emoji]"
 			],
 			[
 				[{}, "[emoji:3]", { content: "string" }],
 				function(result) {
-					assert.ok(emojiRegex.test(result));
-					// there's no reliable method to assert on the length of the string due to unicode implementation weirdness
-					assert.ok(result.length > 2);
+					assert.ok(emojiRegex.test(result), result);
+					assert.ok(result.length, 6);
 				},
 				"should interpolate [emoji:3]"
 			],

--- a/test/index.js
+++ b/test/index.js
@@ -90,4 +90,72 @@ describe("loader-utils", function() {
 			});
 		});
 	});
+
+	describe("#interpolateName", function() {
+		function run(tests) {
+			tests.forEach(function(test) {
+				var args = test[0];
+				var expected = test[1];
+				var message = test[2];
+				it(message, function() {
+					var result = loaderUtils.interpolateName.apply(loaderUtils, args);
+					if (typeof expected === "function") {
+						expected(result);
+					} else {
+						assert.equal(result, expected);
+					}
+				});
+			});
+		}
+
+		run([
+			[[{}, "", { content: "test string" }], "6f8db599de986fab7a21625b7916589c.bin", "should interpolate default tokens"],
+			[[{}, "[hash:base64]", { content: "test string" }], "2sm1pVmS8xuGJLCdWpJoRL", "should interpolate [hash] token with options"],
+			[[{}, "[unrecognized]", { content: "test string" }], "[unrecognized]", "should not interpolate unrecognized token"],
+		]);
+
+		var emojiRegex = /[\uD800-\uDFFF]./;
+		run([
+			[
+				[{}, "[emoji]", { content: "test" }],
+				function(result) {
+					assert.ok(emojiRegex.test(result));
+				},
+				"should interpolate [emoji]"
+			],
+			[
+				[{}, "[emoji:3]", { content: "string" }],
+				function(result) {
+					assert.ok(emojiRegex.test(result));
+					// there's no reliable method to assert on the length of the string due to unicode implementation weirdness
+					assert.ok(result.length > 2);
+				},
+				"should interpolate [emoji:3]"
+			],
+		]);
+		it("should return the same emoji for the same string", function() {
+			var args = [{}, "[emoji:5]", { content: "same_emoji" }];
+			var result1 = loaderUtils.interpolateName.apply(loaderUtils, args);
+			var result2 = loaderUtils.interpolateName.apply(loaderUtils, args);
+			assert.equal(result1, result2);
+		});
+
+		context("no loader context", function() {
+			var loaderContext = {};
+			run([
+				[[loaderContext, "[ext]", {}], "bin", "should interpolate [ext] token"],
+				[[loaderContext, "[name]", {}], "file", "should interpolate [name] token"],
+				[[loaderContext, "[path]", {}], "", "should interpolate [path] token"]
+			]);
+		});
+
+		context("with loader context", function() {
+			var loaderContext = { resourcePath: "/path/to/file.exe" };
+			run([
+				[[loaderContext, "[ext]", {}], "exe", "should interpolate [ext] token"],
+				[[loaderContext, "[name]", {}], "file", "should interpolate [name] token"],
+				[[loaderContext, "[path]", {}], "/path/to/", "should interpolate [path] token"]
+			]);
+		});
+	});
 });


### PR DESCRIPTION
Inspired by [this idea](https://github.com/shiningjason1989/postcss-modules-emoji-classname), I've added the ability to represent a string as a configurable number of emoji. By default, one is assigned per string and it is cached (subsequent calls will produce the same emoji for the same string).