### PR TITLE
getLoaderConfig(): allow multiple default config properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ cheesecakeLoader: {
 }
 ```
 
+#### Default config properties
+
+An arbitrary number of default config property names can be passed. Pass multiple default config properties like so:
+
+```javascript
+config = loaderUtils.getLoaderConfig(this, "some", "someLoader");
+```
+
+The above example will first look for the `some` property in `webpack.config.js`. If that doesn't exist, it will
+look for the `someLoader` property. If that doesn't exist, it will use an empty object.
+
+You may also pass the loader context alone without any default config properties, like so:
+
+```javascript
+config = loaderUtils.getLoaderConfig(this);
+```
+
+The above example will return the equivalent of `loaderUtils.parseQuery(this.query)`.
+
 It is recommended that you use the camelCased loader name as your default config property name.
 
 ### `parseQuery`

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var JSON5 = require("json5");
 var path = require("path");
 var assign = require("object-assign");
+var slice = Array.prototype.slice;
 var emojiRegex = /[\uD800-\uDFFF]./;
 var emojiList = require("emojis-list").filter(function(emoji) {
 	return emojiRegex.test(emoji)
@@ -105,13 +106,16 @@ exports.parseQuery = function parseQuery(query) {
 	return result;
 };
 
-exports.getLoaderConfig = function(loaderContext, defaultConfigKey) {
-	if (!defaultConfigKey) {
-		throw new Error("Default config key missing");
-	}
+exports.getLoaderConfig = function(loaderContext /*, ...defaultConfigKeys */) {
+	var options = loaderContext.options;
 	var query = exports.parseQuery(loaderContext.query);
-	var configKey = query.config || defaultConfigKey;
-	var config = loaderContext.options[configKey] || {};
+
+	var configKeyArray = query.config ? [query.config] : slice.call(arguments, 1);
+	var configKey = configKeyArray.filter(function(key) {
+		return key in options;
+	})[0];
+
+	var config = configKey ? options[configKey] : {};
 
 	delete query.config;
 

--- a/test/index.js
+++ b/test/index.js
@@ -111,23 +111,69 @@ describe("loader-utils", function() {
 	});
 
 	describe("#getLoaderConfig", function() {
-		it("should merge loaderContext.query and loaderContext.options.testLoader", function () {
-			var config = loaderUtils.getLoaderConfig({query:"?name=cheesecake",options:{testLoader:{slices:8}}}, "testLoader");
-			assert.deepEqual(config, {name:"cheesecake",slices:8});
+		describe("no default config keys", function() {
+			it("should allow custom config property via loaderContext.query.config", function() {
+				var config = loaderUtils.getLoaderConfig({
+					query:"?name=cheesecake&config=otherConfig",
+					options:{otherConfig:{slices:8}}
+				});
+				assert.deepEqual(config, {name:"cheesecake",slices:8});
+			});
+			it("should return parseQuery(loaderContext.query) if no loaderContext.query.config", function() {
+				var config = loaderUtils.getLoaderConfig({
+					query:"?name=cheesecake"
+				});
+				assert.deepEqual(config, {name:"cheesecake"});
+			});
 		});
-		it("should allow to specify a config property name via loaderContext.query.config", function () {
-			var config = loaderUtils.getLoaderConfig({query:"?name=cheesecake&config=otherConfig",options:{otherConfig:{slices:8}}}, "testLoader");
-			assert.deepEqual(config, {name:"cheesecake",slices:8});
+
+		describe("one default config key", function() {
+			it("should merge loaderContext.query and loaderContext.options.testLoader", function () {
+				var config = loaderUtils.getLoaderConfig({
+					query:"?name=cheesecake",
+					options:{testLoader:{slices:8}}
+				}, "testLoader");
+				assert.deepEqual(config, {name:"cheesecake",slices:8});
+			});
+			it("should allow to specify a config property name via loaderContext.query.config", function () {
+				var config = loaderUtils.getLoaderConfig({
+					query:"?name=cheesecake&config=otherConfig",
+					options:{otherConfig:{slices:8}}
+				}, "testLoader");
+				assert.deepEqual(config, {name:"cheesecake",slices:8});
+			});
+			it("should prefer loaderContext.query.slices over loaderContext.options.slices", function () {
+				var config = loaderUtils.getLoaderConfig({
+					query:"?slices=8",
+					options:{testLoader:{slices:4}}
+				}, "testLoader");
+				assert.deepEqual(config, {slices:8});
+			});
 		});
-		it("should prefer loaderContext.query.slices over loaderContext.options.slices", function () {
-			var config = loaderUtils.getLoaderConfig({query:"?slices=8",options:{testLoader:{slices:4}}}, "testLoader");
-			assert.deepEqual(config, {slices:8});
-		});
-		it("should throw an error if the default config key is missing", function () {
-			assert.throws(function () {
-				loaderUtils.getLoaderConfig({});
-			}, "Default config key missing")
-		});
+
+		describe("multiple default config keys", function() {
+			it("should accept multiple default config keys", function() {
+				var config = loaderUtils.getLoaderConfig({
+					query: "?name=cheesecake",
+					options: {test: {slices: 8}}
+				}, "testLoader", "test");
+				assert.deepEqual(config, {name: "cheesecake", slices: 8});
+			});
+			it("should use the first config key present on loaderContext.options", function() {
+				var config = loaderUtils.getLoaderConfig({
+					query: "?name=cheesecake",
+					options: {testLoader: {slices: 8}, test: {mices: 8}}
+				}, "testLoader", "test");
+				assert.deepEqual(config, {name: "cheesecake", slices: 8});
+			});
+			it("should ignore if loaderContext.query.config is specified", function() {
+				var config = loaderUtils.getLoaderConfig({
+					query: "?name=cheesecake&config=otherConfig",
+					options: {testLoader: {lices: 8}, test: {mices: 8}, otherConfig: {slices: 8}}
+				}, "testLoader", "test");
+				assert.deepEqual(config, {name: "cheesecake", slices: 8});
+			});
+	  });
 	});
 
 	describe("#getHashDigest", function() {


### PR DESCRIPTION
This PR updates `getLoaderConfig()` to allow the user to pass an arbitrary number of default
config property names to getLoaderConfig(), instead of just one.

See issue #33

This pull request does the following:

- Updates `index.js` as described in issue #33
- Updates `test/index.js` to account for changes
- Updates `README.md` with documentation on new changes