### PR TITLE
Fix regExp option with windows filepaths

### DIFF
--- a/index.js
+++ b/index.js
@@ -287,7 +287,7 @@ exports.interpolateName = function interpolateName(loaderContext, name, options)
 	});
 	if(regExp && loaderContext.resourcePath) {
 		var re = new RegExp(regExp);
-		var match = loaderContext.resourcePath.match(re);
+		var match = loaderContext.resourcePath.replace(/\\/g, "/").match(re);
 		if(match) {
 			for (var i = 0; i < match.length; i++) {
 				var re = new RegExp("\\[" + i + "\\]", "ig");


### PR DESCRIPTION
@sokra We just ran into an issue with this - the `regExp` option (as passed from `css-loader` via `localIdentRegExp`) always normalizes path separators to `"/"`. However, the regex is matched against the un-normalized `loaderContext.resourcePath` path value, leading to false negatives under Windows.

This PR is the fix that we found worked, confirmed via local modifications.

/cc @btm6084
