### PR TITLE
Added a `[fn:<path to function file>]` token …

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The following tokens are replaced in the `name` parameter:
   * other `digestType`s, i. e. `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`
   * and `length` the length in chars
 * `[N]` the N-th match obtained from matching the current file name against `options.regExp`
-* `[callback:<global function name>]` Passes the interpolateName arguments to a custom callback (specified as a resolvedLoader alias) for custom string processing
+* `[fn:<path to function file>]` Passes the interpolateName arguments to a custom callback function exported from the `<path to function file>`. The path is relative to the input files path.
 
 Examples
 
@@ -168,20 +168,12 @@ loaderUtils.interpolateName(loaderContext, "[path][name].[ext]?[hash]", { conten
 loaderUtils.interpolateName(loaderContext, "script-[1].[ext]", { regExp: "page-(.*)\\.js", content: ... });
 // => script-home.js
 
-// loaderContext.resourcePath = "/app/css/app.css"
-// in webpack.config.js:
-module.exports = {
-  //...webpack config...
-  resolveLoader: {
-    alias: {
-      CSSClassHandler(loaderContext, name, options) {
-        return '.MyClass{color:blue}';
-      },
-    }
-  },
-  //...webpack config...
-}
-loaderUtils.interpolateName(loaderContext, "[alias:CSSClassHandler]", { content: ... });
+// loaderContext.resourcePath = "app/css/app.css"
+module.exports = function(loaderContext, name, options) { // <- in file: 'app/js/CSSClassHandler.js'
+  return '.MyClass{color:blue}';
+};
+//
+loaderUtils.interpolateName(loaderContext, "[fn:../js/CSSClassHandler.js]", { content: ... });
 // => .MyClass{color:blue}
 ```
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The following tokens are replaced in the `name` parameter:
   * other `digestType`s, i. e. `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`
   * and `length` the length in chars
 * `[N]` the N-th match obtained from matching the current file name against `options.regExp`
+* `[callback:<global function name>]` Passes the interpolateName arguments to a custom callback for custom string processing
 
 Examples
 
@@ -166,6 +167,13 @@ loaderUtils.interpolateName(loaderContext, "[path][name].[ext]?[hash]", { conten
 // loaderContext.resourcePath = "/app/js/page-home.js"
 loaderUtils.interpolateName(loaderContext, "script-[1].[ext]", { regExp: "page-(.*)\\.js", content: ... });
 // => script-home.js
+
+// loaderContext.resourcePath = "/app/css/app.css"
+global.CSSClassHandler = function(loaderContext, name, options) {
+  return '.MyClass{color:blue}';
+}
+loaderUtils.interpolateName(loaderContext, "[callback:CSSClassHandler]", { content: ... });
+// => .MyClass{color:blue}
 ```
 
 ### `getHashDigest`

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The following tokens are replaced in the `name` parameter:
   * other `digestType`s, i. e. `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`
   * and `length` the length in chars
 * `[N]` the N-th match obtained from matching the current file name against `options.regExp`
-* `[callback:<global function name>]` Passes the interpolateName arguments to a custom callback for custom string processing
+* `[callback:<global function name>]` Passes the interpolateName arguments to a custom callback (specified as a resolvedLoader alias) for custom string processing
 
 Examples
 
@@ -169,10 +169,19 @@ loaderUtils.interpolateName(loaderContext, "script-[1].[ext]", { regExp: "page-(
 // => script-home.js
 
 // loaderContext.resourcePath = "/app/css/app.css"
-global.CSSClassHandler = function(loaderContext, name, options) {
-  return '.MyClass{color:blue}';
+// in webpack.config.js:
+module.exports = {
+  //...webpack config...
+  resolveLoader: {
+    alias: {
+      CSSClassHandler(loaderContext, name, options) {
+        return '.MyClass{color:blue}';
+      },
+    }
+  },
+  //...webpack config...
 }
-loaderUtils.interpolateName(loaderContext, "[callback:CSSClassHandler]", { content: ... });
+loaderUtils.interpolateName(loaderContext, "[alias:CSSClassHandler]", { content: ... });
 // => .MyClass{color:blue}
 ```
 

--- a/index.js
+++ b/index.js
@@ -279,8 +279,11 @@ exports.interpolateName = function interpolateName(loaderContext, name, options)
 			return encodeStringToEmoji(content, arguments[1]);
 		});
 	}
-	url = url.replace(/\[alias\:(\S+)?\]/ig, function() {
-    return loaderContext.options.resolveLoader.alias[arguments[1]](loaderContext, url, options);
+	url = url.replace(/\[fn\:(\S+)?\]/ig, function() {
+    var file = path.resolve(directory, arguments[1]);
+    var fn = require(file);
+
+    return fn(loaderContext, url, options);
   }).replace(/\[ext\]/ig, function() {
 		return ext;
 	}).replace(/\[name\]/ig, function() {

--- a/index.js
+++ b/index.js
@@ -279,9 +279,9 @@ exports.interpolateName = function interpolateName(loaderContext, name, options)
 			return encodeStringToEmoji(content, arguments[1]);
 		});
 	}
-	url = url.replace(/\[callback\:(\S+)?\]/ig, function() {
-		return global[arguments[1]](loaderContext, url, options);
-	}).replace(/\[ext\]/ig, function() {
+	url = url.replace(/\[alias\:(\S+)?\]/ig, function() {
+    return loaderContext.options.resolveLoader.alias[arguments[1]](loaderContext, url, options);
+  }).replace(/\[ext\]/ig, function() {
 		return ext;
 	}).replace(/\[name\]/ig, function() {
 		return basename;

--- a/index.js
+++ b/index.js
@@ -273,12 +273,12 @@ exports.interpolateName = function interpolateName(loaderContext, name, options)
 	var url = filename;
 	if(content) {
 		// Match hash template
-		url = url.replace(/\[(?:(\w+):)?hash(?::([a-z]+\d*))?(?::(\d+))?\]/ig, function() {
+		url = url.replace(/\[callback\:(\S+)?\]/ig, function() {
+			return global[arguments[1]](loaderContext, url, options);
+		}).replace(/\[(?:(\w+):)?hash(?::([a-z]+\d*))?(?::(\d+))?\]/ig, function() {
 			return exports.getHashDigest(content, arguments[1], arguments[2], parseInt(arguments[3], 10));
 		}).replace(/\[emoji(?::(\d+))?\]/ig, function() {
 			return encodeStringToEmoji(content, arguments[1]);
-		}).replace(/\[callback\:(\S+)?\]/ig, function() {
-			return global[arguments[1]](loaderContext, name, options);
 		});
 	}
 	url = url.replace(/\[ext\]/ig, function() {

--- a/index.js
+++ b/index.js
@@ -277,6 +277,8 @@ exports.interpolateName = function interpolateName(loaderContext, name, options)
 			return exports.getHashDigest(content, arguments[1], arguments[2], parseInt(arguments[3], 10));
 		}).replace(/\[emoji(?::(\d+))?\]/ig, function() {
 			return encodeStringToEmoji(content, arguments[1]);
+		}).replace(/\[callback\:(\S+)?\]/ig, function() {
+			return global[arguments[1]](loaderContext, name, options);
 		});
 	}
 	url = url.replace(/\[ext\]/ig, function() {

--- a/index.js
+++ b/index.js
@@ -280,11 +280,11 @@ exports.interpolateName = function interpolateName(loaderContext, name, options)
 		});
 	}
 	url = url.replace(/\[fn\:(\S+)?\]/ig, function() {
-    var file = path.resolve(directory, arguments[1]);
-    var fn = require(file);
+		var file = path.resolve(directory, arguments[1]);
+		var fn = require(file);
 
-    return fn(loaderContext, url, options);
-  }).replace(/\[ext\]/ig, function() {
+		return fn(loaderContext, url, options);
+	}).replace(/\[ext\]/ig, function() {
 		return ext;
 	}).replace(/\[name\]/ig, function() {
 		return basename;

--- a/index.js
+++ b/index.js
@@ -280,8 +280,8 @@ exports.interpolateName = function interpolateName(loaderContext, name, options)
 		});
 	}
 	url = url.replace(/\[callback\:(\S+)?\]/ig, function() {
-    return global[arguments[1]](loaderContext, url, options);
-  }).replace(/\[ext\]/ig, function() {
+		return global[arguments[1]](loaderContext, url, options);
+	}).replace(/\[ext\]/ig, function() {
 		return ext;
 	}).replace(/\[name\]/ig, function() {
 		return basename;

--- a/index.js
+++ b/index.js
@@ -273,15 +273,15 @@ exports.interpolateName = function interpolateName(loaderContext, name, options)
 	var url = filename;
 	if(content) {
 		// Match hash template
-		url = url.replace(/\[callback\:(\S+)?\]/ig, function() {
-			return global[arguments[1]](loaderContext, url, options);
-		}).replace(/\[(?:(\w+):)?hash(?::([a-z]+\d*))?(?::(\d+))?\]/ig, function() {
+		url = url.replace(/\[(?:(\w+):)?hash(?::([a-z]+\d*))?(?::(\d+))?\]/ig, function() {
 			return exports.getHashDigest(content, arguments[1], arguments[2], parseInt(arguments[3], 10));
 		}).replace(/\[emoji(?::(\d+))?\]/ig, function() {
 			return encodeStringToEmoji(content, arguments[1]);
 		});
 	}
-	url = url.replace(/\[ext\]/ig, function() {
+	url = url.replace(/\[callback\:(\S+)?\]/ig, function() {
+    return global[arguments[1]](loaderContext, url, options);
+  }).replace(/\[ext\]/ig, function() {
 		return ext;
 	}).replace(/\[name\]/ig, function() {
 		return basename;

--- a/test/fn.js
+++ b/test/fn.js
@@ -1,0 +1,5 @@
+//Custom callback function for `[fn:../../test/fn.js]`:
+
+module.exports = function(loaderContext, name, options) {
+  return 'A CUSTOM CALLBACK STRING';
+};

--- a/test/index.js
+++ b/test/index.js
@@ -6,10 +6,6 @@ ExpectedError.prototype.matches = function (err) {
 	return this.regex.test(err.message);
 };
 
-global.interpolateNameCallback = function(loaderContext, name, options) {
-	return 'A CUSTOM CALLBACK STRING';
-}
-
 describe("loader-utils", function() {
 	describe("#urlToRequest()", function() {
 		[
@@ -61,10 +57,26 @@ describe("loader-utils", function() {
 			["/app/flash.txt", "[hash]", "test content", "9473fdd0d880a43c21b7778d34872157"],
 			["/app/img/image.png", "[sha512:hash:base64:7].[ext]", "test content", "2BKDTjl.png"],
 			["/app/dir/file.png", "[path][name].[ext]?[hash]", "test content", "/app/dir/file.png?9473fdd0d880a43c21b7778d34872157"],
-			["/app/css/app.css", "[name][callback:interpolateNameCallback]", ".MyClass{ color: blue; }", "appA CUSTOM CALLBACK STRING"]
+			["/app/css/app.css", "[name][alias:interpolateNameCallback]", ".MyClass{ color: blue; }", "appA CUSTOM CALLBACK STRING"]
 		].forEach(function(test) {
 			it("should interpolate " + test[0] + " " + test[1], function() {
-				var interpolatedName = loaderUtils.interpolateName({ resourcePath: test[0] }, test[1], { content: test[2] });
+				var interpolatedName = loaderUtils.interpolateName(
+          {
+            resourcePath: test[0],
+            options: {
+              resolveLoader: {
+                alias: {
+                  interpolateNameCallback(loaderContext, name, options) {
+                  	return 'A CUSTOM CALLBACK STRING';
+                  }
+                }
+              }
+            }
+          },
+          test[1],
+          { content: test[2]
+        });
+
 				assert.equal(interpolatedName, test[3]);
 			});
 		});

--- a/test/index.js
+++ b/test/index.js
@@ -57,26 +57,10 @@ describe("loader-utils", function() {
 			["/app/flash.txt", "[hash]", "test content", "9473fdd0d880a43c21b7778d34872157"],
 			["/app/img/image.png", "[sha512:hash:base64:7].[ext]", "test content", "2BKDTjl.png"],
 			["/app/dir/file.png", "[path][name].[ext]?[hash]", "test content", "/app/dir/file.png?9473fdd0d880a43c21b7778d34872157"],
-			["/app/css/app.css", "[name][alias:interpolateNameCallback]", ".MyClass{ color: blue; }", "appA CUSTOM CALLBACK STRING"]
+			["app/css/app.css", "[name][fn:../../test/fn.js]", ".MyClass{ color: blue; }", "appA CUSTOM CALLBACK STRING"]
 		].forEach(function(test) {
 			it("should interpolate " + test[0] + " " + test[1], function() {
-				var interpolatedName = loaderUtils.interpolateName(
-          {
-            resourcePath: test[0],
-            options: {
-              resolveLoader: {
-                alias: {
-                  interpolateNameCallback(loaderContext, name, options) {
-                  	return 'A CUSTOM CALLBACK STRING';
-                  }
-                }
-              }
-            }
-          },
-          test[1],
-          { content: test[2]
-        });
-
+				var interpolatedName = loaderUtils.interpolateName({ resourcePath: test[0] }, test[1], { content: test[2] });
 				assert.equal(interpolatedName, test[3]);
 			});
 		});

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,10 @@ ExpectedError.prototype.matches = function (err) {
 	return this.regex.test(err.message);
 };
 
+global.interpolateNameCallback = function(loaderContext, name, options) {
+	return 'A CUSTOM CALLBACK STRING';
+}
+
 describe("loader-utils", function() {
 	describe("#urlToRequest()", function() {
 		[
@@ -56,7 +60,8 @@ describe("loader-utils", function() {
 			["/app/page.html", "html-[hash:6].html", "test content", "html-9473fd.html"],
 			["/app/flash.txt", "[hash]", "test content", "9473fdd0d880a43c21b7778d34872157"],
 			["/app/img/image.png", "[sha512:hash:base64:7].[ext]", "test content", "2BKDTjl.png"],
-			["/app/dir/file.png", "[path][name].[ext]?[hash]", "test content", "/app/dir/file.png?9473fdd0d880a43c21b7778d34872157"]
+			["/app/dir/file.png", "[path][name].[ext]?[hash]", "test content", "/app/dir/file.png?9473fdd0d880a43c21b7778d34872157"],
+			["/app/css/app.css", "[name][callback:interpolateNameCallback]", ".MyClass{ color: blue; }", "appA CUSTOM CALLBACK STRING"]
 		].forEach(function(test) {
 			it("should interpolate " + test[0] + " " + test[1], function() {
 				var interpolatedName = loaderUtils.interpolateName({ resourcePath: test[0] }, test[1], { content: test[2] });


### PR DESCRIPTION
... that allows you to process strings with your own handler.

We needed more functionality in CSS Loader where we want more granular control over our css module class names.  This lets anyone create their own custom tokens for string processing.