### PR TITLE
Support for CRC hash (fixes #48 )

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,6 +223,12 @@ exports.parseString = function parseString(str) {
 exports.getHashDigest = function getHashDigest(buffer, hashType, digestType, maxLength) {
 	hashType = hashType || "md5";
 	maxLength = maxLength || 9999;
+
+	if (hashType.match(/^crc(?:1|8|16|24|32)$/)){
+		var base = digestType && digestType.match(/^base\d{1,2}/) ? parseInt(digestType.match(/\d+/)[0]) : 16;
+		return require("crc")[hashType](buffer).toString(base).substr(0, maxLength);
+	}
+
 	var hash = require("crypto").createHash(hashType);
 	hash.update(buffer);
 	if (digestType === "base26" || digestType === "base32" || digestType === "base36" ||

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "utils for webpack loaders",
   "dependencies": {
     "big.js": "^3.1.3",
+    "crc": "^3.4.3",
     "emojis-list": "^2.0.0",
     "json5": "^0.5.0",
     "object-assign": "^4.0.1"

--- a/test/index.js
+++ b/test/index.js
@@ -141,7 +141,12 @@ describe("loader-utils", function() {
 			["test string", "md5", "base52", undefined, "dJnldHSAutqUacjgfBQGLQx"],
 			["test string", "md5", "base26", 6, "bhtsgu"],
 			["test string", "sha512", "base64", undefined, "2IS-kbfIPnVflXb9CzgoNESGCkvkb0urMmucPD9z8q6HuYz8RShY1-tzSUpm5-Ivx_u4H1MEzPgAhyhaZ7RKog"],
-			["test_string", "md5", "hex", undefined, "3474851a3410906697ec77337df7aae4"]
+			["test_string", "md5", "hex", undefined, "3474851a3410906697ec77337df7aae4"],
+			["test string", "crc32", "base10", undefined, "323425605"],
+			["test string", "crc32", "hex", undefined, "13471545"],
+			["test string", "crc32", "base16", undefined, "13471545"],
+			["test string", "crc32", "base16", 4, "1347"],
+			["test string", "crc32", "base36", undefined, "5ck4sl"]
 		].forEach(function(test) {
 			it("should getHashDigest " + test[0] + " " + test[1] + " " + test[2] + " " + test[3], function() {
 				var hashDigest = loaderUtils.getHashDigest(test[0], test[1], test[2], test[3]);


### PR DESCRIPTION
This pull-request adds support for CRC checksums as hashes by using the [node-crc](https://github.com/alexgorbatchev/node-crc) library. 

Adds these allowed values to hashType: `crc1`, `crc8`, `crc16`, `crc24`, `crc32`.

Can be used in combination with up to `base36` digestType (since it's just implemented with `Number.toString`).

Not sure this is a broad enough use-case to be merged or if it's better solved in another way. Feel free to reject if that's the case.