### PR TITLE
Allow function interpolation

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,7 +249,13 @@ exports.getHashDigest = function getHashDigest(buffer, hashType, digestType, max
 };
 
 exports.interpolateName = function interpolateName(loaderContext, name, options) {
-	var filename = name || "[hash].[ext]";
+	var filename;
+	if (name instanceof Function) {
+		filename = name(loaderContext.resourcePath);
+	} else {
+		filename = name || "[hash].[ext]";
+	}
+
 	var context = options.context;
 	var content = options.content;
 	var regExp = options.regExp;

--- a/index.js
+++ b/index.js
@@ -250,12 +250,11 @@ exports.getHashDigest = function getHashDigest(buffer, hashType, digestType, max
 
 exports.interpolateName = function interpolateName(loaderContext, name, options) {
 	var filename;
-	if (name instanceof Function) {
+	if (typeof name === 'function') {
 		filename = name(loaderContext.resourcePath);
 	} else {
 		filename = name || "[hash].[ext]";
 	}
-
 	var context = options.context;
 	var content = options.content;
 	var regExp = options.regExp;

--- a/index.js
+++ b/index.js
@@ -250,7 +250,7 @@ exports.getHashDigest = function getHashDigest(buffer, hashType, digestType, max
 
 exports.interpolateName = function interpolateName(loaderContext, name, options) {
 	var filename;
-	if (typeof name === 'function') {
+	if (typeof name == 'function') {
 		filename = name(loaderContext.resourcePath);
 	} else {
 		filename = name || "[hash].[ext]";

--- a/test/index.js
+++ b/test/index.js
@@ -57,7 +57,8 @@ describe("loader-utils", function() {
 			["/app/page.html", "html-[hash:6].html", "test content", "html-9473fd.html"],
 			["/app/flash.txt", "[hash]", "test content", "9473fdd0d880a43c21b7778d34872157"],
 			["/app/img/image.png", "[sha512:hash:base64:7].[ext]", "test content", "2BKDTjl.png"],
-			["/app/dir/file.png", "[path][name].[ext]?[hash]", "test content", "/app/dir/file.png?9473fdd0d880a43c21b7778d34872157"]
+			["/app/dir/file.png", "[path][name].[ext]?[hash]", "test content", "/app/dir/file.png?9473fdd0d880a43c21b7778d34872157"],
+			["/vendor/test/images/loading.gif", function(path) { return path.replace(/\/?vendor\/?/, ''); }, "test content", "test/images/loading.gif"]
 		].forEach(function(test) {
 			it("should interpolate " + test[0] + " " + test[1], function() {
 				var interpolatedName = loaderUtils.interpolateName({ resourcePath: test[0] }, test[1], { content: test[2] });


### PR DESCRIPTION
Currently generating names is quite restrictive - it only allows a fix number of opportunities.
I propose letting the `name` parameter to be a function, so developers can return whatever name they want based on the resource path with their own logic.
As a real-life example, I would like assets in `node_modules` to be in a subfolder of `images` named after the package, while assets from other paths should be placed in the root of `images`. Currently I haven't found a way to achieve this.

There should be no breaking change to existing configurations.