### PR TITLE
Handle periods in directory names when interpolating paths

### DIFF
--- a/lib/interpolateName.js
+++ b/lib/interpolateName.js
@@ -37,18 +37,15 @@ function interpolateName(loaderContext, name, options) {
 	let directory = "";
 	let folder = "";
 	if(loaderContext.resourcePath) {
+		const parsed = path.parse(loaderContext.resourcePath);
 		let resourcePath = loaderContext.resourcePath;
-		const idx = resourcePath.lastIndexOf(".");
-		const i = resourcePath.lastIndexOf("\\");
-		const j = resourcePath.lastIndexOf("/");
-		const p = i < 0 ? j : j < 0 ? i : i < j ? i : j;
-		if(idx >= 0) {
-			ext = resourcePath.substr(idx + 1);
-			resourcePath = resourcePath.substr(0, idx);
+
+		if(parsed.ext) {
+			ext = parsed.ext.substr(1);
 		}
-		if(p >= 0) {
-			basename = resourcePath.substr(p + 1);
-			resourcePath = resourcePath.substr(0, p + 1);
+		if(parsed.dir) {
+			basename = parsed.name;
+			resourcePath = parsed.dir + path.sep;
 		}
 		if(typeof context !== "undefined") {
 			directory = path.relative(context, resourcePath + "_").replace(/\\/g, "/").replace(/\.\.(\/)?/g, "_$1");

--- a/test/interpolateName.test.js
+++ b/test/interpolateName.test.js
@@ -28,7 +28,9 @@ describe("interpolateName()", () => {
 		["/app/flash.txt", "[hash]", "test content", "9473fdd0d880a43c21b7778d34872157"],
 		["/app/img/image.png", "[sha512:hash:base64:7].[ext]", "test content", "2BKDTjl.png"],
 		["/app/dir/file.png", "[path][name].[ext]?[hash]", "test content", "/app/dir/file.png?9473fdd0d880a43c21b7778d34872157"],
-		["/vendor/test/images/loading.gif", path => path.replace(/\/?vendor\/?/, ""), "test content", "test/images/loading.gif"]
+		["/vendor/test/images/loading.gif", path => path.replace(/\/?vendor\/?/, ""), "test content", "test/images/loading.gif"],
+		["/pathWith.period/filename.js", "js/[name].[ext]", "test content", "js/filename.js"],
+		["/pathWith.period/filenameWithoutExt", "js/[name].[ext]", "test content", "js/filenameWithoutExt.bin"]
 	].forEach(test => {
 		it("should interpolate " + test[0] + " " + test[1], () => {
 			const interpolatedName = loaderUtils.interpolateName({ resourcePath: test[0] }, test[1], { content: test[2] });


### PR DESCRIPTION
Given:
   - A filename without an extension, and
   - A directory path containing a period

...the result from `interpolateName` is wrong. I've reworked the code and added some tests to cover this.