### PR TITLE
Fixes "[hash]" token regex in interpolateString to capture any hash algorithm name

### DIFF
--- a/lib/interpolateName.js
+++ b/lib/interpolateName.js
@@ -64,7 +64,7 @@ function interpolateName(loaderContext, name, options) {
 		// Match hash template
 		url = url
 			.replace(
-				/\[(?:(\w+):)?hash(?::([a-z]+\d*))?(?::(\d+))?\]/ig,
+				/\[(?:([^:]+):)?hash(?::([a-z]+\d*))?(?::(\d+))?\]/ig,
 				(all, hashType, digestType, maxLength) => getHashDigest(content, hashType, digestType, parseInt(maxLength, 10))
 			)
 			.replace(

--- a/test/interpolateName.test.js
+++ b/test/interpolateName.test.js
@@ -38,22 +38,22 @@ describe("interpolateName()", () => {
 		});
 	});
 
-	[ 'sha1fakename',
-		'9dxfakename',
-	  'RSA-SHA256-fakename',
-	  'ecdsa-with-SHA1-fakename',
-		'tls1.1-sha512-fakename',
+	[ "sha1fakename",
+		"9dxfakename",
+		"RSA-SHA256-fakename",
+		"ecdsa-with-SHA1-fakename",
+		"tls1.1-sha512-fakename",
 	].forEach(hashName => {
 		it("should pick hash algorithm by name " + hashName, () => {
 			assert.throws(
 				() => {
 					const interpolatedName = loaderUtils.interpolateName(
-						{}, '[' + hashName + ':hash:base64:10]', {content:'a'}
+						{ }, "[" + hashName + ":hash:base64:10]", {content:"a"}
 					);
 					// if for any reason the system we're running on has a hash
 					// algorithm matching any of our bogus names, at least make sure
 					// the output is not the unmodified name:
-					assert(interpolatedName[0] != '[');
+					assert(interpolatedName[0] !== '[');
 				},
 				/digest method not supported/i
 			);

--- a/test/interpolateName.test.js
+++ b/test/interpolateName.test.js
@@ -38,6 +38,29 @@ describe("interpolateName()", () => {
 		});
 	});
 
+	[ 'sha1fakename',
+		'9dxfakename',
+	  'RSA-SHA256-fakename',
+	  'ecdsa-with-SHA1-fakename',
+		'tls1.1-sha512-fakename',
+	].forEach(hashName => {
+		it("should pick hash algorithm by name " + hashName, () => {
+			assert.throws(
+				() => {
+					const interpolatedName = loaderUtils.interpolateName(
+						{}, '[' + hashName + ':hash:base64:10]', {content:'a'}
+					);
+					// if for any reason the system we're running on has a hash
+					// algorithm matching any of our bogus names, at least make sure
+					// the output is not the unmodified name:
+					assert(interpolatedName[0] != '[');
+				},
+				/digest method not supported/i
+			);
+		});
+	});
+
+
 	run([
 		[[{}, "", { content: "test string" }], "6f8db599de986fab7a21625b7916589c.bin", "should interpolate default tokens"],
 		[[{}, "[hash:base64]", { content: "test string" }], "2sm1pVmS8xuGJLCdWpJoRL", "should interpolate [hash] token with options"],


### PR DESCRIPTION
Without this patch the following does not work:

```js
const interpolateName = require('./lib/interpolateName')
interpolateName({}, '[RSA-SHA256:hash:base64:10]', {content:'a'})
```

Because the regex for matching the hash type in [interpolateName.js](https://github.com/webpack/loader-utils/blob/master/lib/interpolateName.js#L67) looks for `\w+` which only includes word characters (which does not include "-", "_" or other characters used in some hash algorithm names.)