### PR TITLE
Fix demonstrated usage of Object.assign in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ If you pass it on to another library, make sure to make a *deep copy* of it:
 ```javascript
 const options = Object.assign(
 	{},
-	loaderUtils.getOptions(this), // it is safe to pass null to Object.assign()
-	defaultOptions
+	defaultOptions,
+	loaderUtils.getOptions(this) // it is safe to pass null to Object.assign()
 );
 // don't forget nested objects or arrays
 options.obj = Object.assign({}, options.obj); 


### PR DESCRIPTION
What the current README suggests would override provided options with the default options:

```js
Object.assign({}, {option: "provided"}, {option: "someDefault"}) // => {option: "someDefault"}
```

I imagine this is the opposite of what was intended.

BTW, thanks for Webpack! I love it.