### PR TITLE
Fix URLs for web extension protocols for edge and firefox wrongly detected as requests

### DIFF
--- a/lib/isUrlRequest.js
+++ b/lib/isUrlRequest.js
@@ -5,7 +5,7 @@ function isUrlRequest(url, root) {
 	// 1. it's a Data Url
 	// 2. it's an absolute url or and protocol-relative
 	// 3. it's some kind of url for a template
-	if(/^data:|^chrome-extension:|^(https?:)?\/\/|^[\{\}\[\]#*;,'§\$%&\(=?`´\^°<>]/.test(url)) return false;
+	if(/^data:|^chrome-extension:|^moz-extension:|^ms-browser-extension:|^(https?:)?\/\/|^[\{\}\[\]#*;,'§\$%&\(=?`´\^°<>]/.test(url)) return false;
 	// 4. It's also not an request if root isn't set and it's a root-relative url
 	if((root === undefined || root === false) && /^\//.test(url)) return false;
 	return true;

--- a/test/isUrlRequest.test.js
+++ b/test/isUrlRequest.test.js
@@ -1,0 +1,61 @@
+"use strict";
+
+const assert = require("assert");
+const loaderUtils = require("../");
+
+function ExpectedError(regex) {
+	this.regex = regex;
+}
+ExpectedError.prototype.matches = function(err) {
+	return this.regex.test(err.message);
+};
+
+describe("isUrlRequest()", () => {
+	[
+		// without root
+		[["//google.com"], false, "should be negative for scheme-agnostic urls"],
+		[["http://google.com"], false, "should be negative for http urls"],
+		[["https://google.com"], false, "should be negative for https urls"],
+		[["chrome-extension://"], false, "should be negative for https urls"],
+		[["moz-extension://"], false, "should be negative for https urls"],
+		[["ms-browser-extension://"], false, "should be negative for https urls"],
+		[["path/to/thing"], true, "should be positive for implicit relative urls"],
+		[["./path/to/thing"], true, "should be positive for explicit relative urls"],
+		[["~path/to/thing"], true, "should be positive for module urls (with ~)"],
+		[["some/other/stuff/and/then~path/to/thing"], true, "should be positive for module urls with path prefix"],
+		[["./some/other/stuff/and/then~path/to/thing"], true, "should be positive for module urls with relative path prefix"],
+		// with root (normal path)
+		[["path/to/thing", "root/dir"], true, "should be positive with root if implicit relative url"],
+		[["./path/to/thing", "root/dir"], true, "should be positive with root if explicit relative url"],
+		[["/path/to/thing", "root/dir"], true, "should be positive with root if root-relative url"],
+		// with root (boolean)
+		[["/path/to/thing", true], true, "should be positive for root-relative if root = `true`"],
+		// with root (boolean) on Windows
+		[["C:\\path\\to\\thing"], true, "should be positive for Windows absolute paths with drive letter"],
+		[["\\\\?\\UNC\\ComputerName\\path\\to\\thing"], true, "should be positive for Windows absolute UNC paths"],
+		// with root (module)
+		[["/path/to/thing", "~"], true, "should be positive for module url if root = ~"],
+		// with root (module path)
+		[["/path/to/thing", "~module"], true, "should be positive for module prefixes when root starts with ~"],
+		[["/path/to/thing", "~module/"], true, "should be positive for module prefixes (with trailing slash) when root starts with ~"],
+		// error cases
+		[["/path/to/thing", 1], new ExpectedError(/unexpected parameters/i), "should throw an error on invalid root"],
+
+		// empty url
+		[[""], true, "should be positive if url is empty"]
+	].forEach((test) => {
+		it(test[2], () => {
+			const expected = test[1];
+			try {
+				const request = loaderUtils.isUrlRequest.apply(loaderUtils, test[0]);
+				assert.equal(request, expected);
+			} catch(e) {
+				if(expected instanceof ExpectedError) {
+					assert.ok(expected.matches(e));
+				} else {
+					assert.ok(false, "should not have thrown an error: " + e.message);
+				}
+			}
+		});
+	});
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -596,11 +596,11 @@ es6-weak-map@^2.0.1:
     es6-iterator "2"
     es6-symbol "3"
 
-escape-string-regexp@1.0.2:
+escape-string-regexp@1.0.2, escape-string-regexp@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 


### PR DESCRIPTION
In webpack, URLs like:
```
ms-browser-extension://path/to/something
moz-extension://path/to/something
```

Would throw errors like
```
Module not found: Error: Can't resolve './ms-browser-extension://path/to/something'
```

But `chrome-extension://` URLs would work as expected.

This PR fixes that.