### PR TITLE
Parse string for emoji count before use.

### DIFF
--- a/lib/interpolateName.js
+++ b/lib/interpolateName.js
@@ -69,7 +69,7 @@ function interpolateName(loaderContext, name, options) {
 			)
 			.replace(
 				/\[emoji(?::(\d+))?\]/ig,
-				(all, length) => encodeStringToEmoji(content, length)
+				(all, length) => encodeStringToEmoji(content, parseInt(length, 10))
 			);
 	}
 	url = url


### PR DESCRIPTION
Was seeing an issue where webpack wasn't working correctly in some circumstances, so changed over to explicitly cast instead of relying on the `--` inside the function.