### PR TITLE
urlToRequest add alias support

### DIFF
--- a/lib/urlToRequest.js
+++ b/lib/urlToRequest.js
@@ -3,11 +3,23 @@
 // we can't use path.win32.isAbsolute because it also matches paths starting with a forward slash
 const matchNativeWin32Path = /^[A-Z]:[/\\]|^\\\\/i;
 
-function urlToRequest(url, root) {
+function urlToRequest(url, root, aliases) {
 	// Do not rewrite an empty url
 	if(url === "") {
 		return "";
 	}
+
+	// ---------- handle alias start -------------
+	// if url start with one of the alias( webpack option.resolve.alias ), consider it`s no need to transform
+	if(Array.isArray(aliases)) {
+		const alias = aliases.find((alias) => {
+			return url.startsWith(alias);
+		});
+		if(undefined !== alias) {
+			return url;
+		}
+	}
+	// ---------- handle alias end -------------
 
 	const moduleRequestRegex = /^[^?]*~/;
 	let request;

--- a/test/urlToRequest.test.js
+++ b/test/urlToRequest.test.js
@@ -40,7 +40,9 @@ describe("urlToRequest()", () => {
 		// difficult cases
 		[["a:b-not-\\window-path"], "./a:b-not-\\window-path", "should not incorrectly detect windows paths"],
 		// empty url
-		[[""], "", "should do nothing if url is empty"]
+		[[""], "", "should do nothing if url is empty"],
+		// start with alias
+		[["@css/reset.css", "", ["@css"]], "@css/reset.css", "should do nothing if url is start with alias"]
 	].forEach((test) => {
 		it(test[2], () => {
 			const expected = test[1];


### PR DESCRIPTION
if url start with one of the alias( webpack option.resolve.alias ), consider it is no need to transform