### PR TITLE
Use MD4 instead of MD5 as default hashType

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const options = Object.assign(
 	loaderUtils.getOptions(this) // it is safe to pass null to Object.assign()
 );
 // don't forget nested objects or arrays
-options.obj = Object.assign({}, options.obj); 
+options.obj = Object.assign({}, options.obj);
 options.arr = options.arr.slice();
 someLibrary(options);
 ```
@@ -164,9 +164,9 @@ The following tokens are replaced in the `name` parameter:
 * `[folder]` the folder of the resource is in.
 * `[emoji]` a random emoji representation of `options.content`
 * `[emoji:<length>]` same as above, but with a customizable number of emojis
-* `[hash]` the hash of `options.content` (Buffer) (by default it's the hex digest of the md5 hash)
+* `[hash]` the hash of `options.content` (Buffer) (by default it's the hex digest of the md4 hash)
 * `[<hashType>:hash:<digestType>:<length>]` optionally one can configure
-  * other `hashType`s, i. e. `sha1`, `md5`, `sha256`, `sha512`
+  * other `hashType`s, i. e. `sha1`, `md4`, `md5`, `sha256`, `sha512`
   * other `digestType`s, i. e. `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`
   * and `length` the length in chars
 * `[N]` the N-th match obtained from matching the current file name against `options.regExp`
@@ -197,7 +197,7 @@ loaderUtils.interpolateName(loaderContext, "[emoji:4]", { content: ... });
 // loaderContext.resourcePath = "/app/img/image.png"
 loaderUtils.interpolateName(loaderContext, "[sha512:hash:base64:7].[ext]", { content: ... });
 // => 2BKDTjl.png
-// use sha512 hash instead of md5 and with only 7 chars of base64
+// use sha512 hash instead of md4 and with only 7 chars of base64
 
 // loaderContext.resourcePath = "/app/img/myself.png"
 // loaderContext.query.name =
@@ -220,7 +220,7 @@ const digestString = loaderUtils.getHashDigest(buffer, hashType, digestType, max
 ```
 
 * `buffer` the content that should be hashed
-* `hashType` one of `sha1`, `md5`, `sha256`, `sha512` or any other node.js supported hash type
+* `hashType` one of `sha1`, `md4`, `md5`, `sha256`, `sha512` or any other node.js supported hash type
 * `digestType` one of `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`
 * `maxLength` the maximum length in chars
 

--- a/lib/getHashDigest.js
+++ b/lib/getHashDigest.js
@@ -37,7 +37,7 @@ function encodeBufferToBase(buffer, base) {
 }
 
 function getHashDigest(buffer, hashType, digestType, maxLength) {
-	hashType = hashType || "md5";
+	hashType = hashType || "md4";
 	maxLength = maxLength || 9999;
 	const hash = require("crypto").createHash(hashType);
 	hash.update(buffer);

--- a/test/getHashDigest.test.js
+++ b/test/getHashDigest.test.js
@@ -11,7 +11,8 @@ describe("getHashDigest()", () => {
 		["test string", "md5", "base52", undefined, "dJnldHSAutqUacjgfBQGLQx"],
 		["test string", "md5", "base26", 6, "bhtsgu"],
 		["test string", "sha512", "base64", undefined, "2IS-kbfIPnVflXb9CzgoNESGCkvkb0urMmucPD9z8q6HuYz8RShY1-tzSUpm5-Ivx_u4H1MEzPgAhyhaZ7RKog"],
-		["test string", "md5", "hex", undefined, "6f8db599de986fab7a21625b7916589c"]
+		["test string", "md5", "hex", undefined, "6f8db599de986fab7a21625b7916589c"],
+		["test string", "md4", "hex", undefined, "2e06edd4f1623268c5a51730d8a0b2af"]
 	].forEach(test => {
 		it("should getHashDigest " + test[0] + " " + test[1] + " " + test[2] + " " + test[3], () => {
 			const hashDigest = loaderUtils.getHashDigest(test[0], test[1], test[2], test[3]);

--- a/test/interpolateName.test.js
+++ b/test/interpolateName.test.js
@@ -23,11 +23,11 @@ describe("interpolateName()", () => {
 	}
 
 	[
-		["/app/js/javascript.js", "js/[hash].script.[ext]", "test content", "js/9473fdd0d880a43c21b7778d34872157.script.js"],
-		["/app/page.html", "html-[hash:6].html", "test content", "html-9473fd.html"],
-		["/app/flash.txt", "[hash]", "test content", "9473fdd0d880a43c21b7778d34872157"],
+		["/app/js/javascript.js", "js/[hash].script.[ext]", "test content", "js/a69899814931280e2f527219ad6ac754.script.js"],
+		["/app/page.html", "html-[hash:6].html", "test content", "html-a69899.html"],
+		["/app/flash.txt", "[hash]", "test content", "a69899814931280e2f527219ad6ac754"],
 		["/app/img/image.png", "[sha512:hash:base64:7].[ext]", "test content", "2BKDTjl.png"],
-		["/app/dir/file.png", "[path][name].[ext]?[hash]", "test content", "/app/dir/file.png?9473fdd0d880a43c21b7778d34872157"],
+		["/app/dir/file.png", "[path][name].[ext]?[hash]", "test content", "/app/dir/file.png?a69899814931280e2f527219ad6ac754"],
 		["/vendor/test/images/loading.gif", path => path.replace(/\/?vendor\/?/, ""), "test content", "test/images/loading.gif"],
 		["/pathWith.period/filename.js", "js/[name].[ext]", "test content", "js/filename.js"],
 		["/pathWith.period/filenameWithoutExt", "js/[name].[ext]", "test content", "js/filenameWithoutExt.bin"]
@@ -48,12 +48,12 @@ describe("interpolateName()", () => {
 			assert.throws(
 				() => {
 					const interpolatedName = loaderUtils.interpolateName(
-						{ }, "[" + hashName + ":hash:base64:10]", {content:"a"}
+						{ }, "[" + hashName + ":hash:base64:10]", { content: "a" }
 					);
 					// if for any reason the system we're running on has a hash
 					// algorithm matching any of our bogus names, at least make sure
 					// the output is not the unmodified name:
-					assert(interpolatedName[0] !== '[');
+					assert(interpolatedName[0] !== "[");
 				},
 				/digest method not supported/i
 			);
@@ -62,8 +62,8 @@ describe("interpolateName()", () => {
 
 
 	run([
-		[[{}, "", { content: "test string" }], "6f8db599de986fab7a21625b7916589c.bin", "should interpolate default tokens"],
-		[[{}, "[hash:base64]", { content: "test string" }], "2sm1pVmS8xuGJLCdWpJoRL", "should interpolate [hash] token with options"],
+		[[{}, "", { content: "test string" }], "2e06edd4f1623268c5a51730d8a0b2af.bin", "should interpolate default tokens"],
+		[[{}, "[hash:base64]", { content: "test string" }], "2LIG3oc1uBNmwOoL7kXgoK", "should interpolate [hash] token with options"],
 		[[{}, "[unrecognized]", { content: "test string" }], "[unrecognized]", "should not interpolate unrecognized token"],
 		[
 			[{}, "[emoji]", { content: "test" }],


### PR DESCRIPTION
As #114 says. Several lint issues are fixed too to make `npm run test` pass