### PR TITLE
Feature: add compiler output options support for hash

### DIFF
--- a/lib/interpolateName.js
+++ b/lib/interpolateName.js
@@ -64,12 +64,18 @@ function interpolateName(loaderContext, name, options) {
 		}
 	}
 	let url = filename;
+	const compilationOutputOptions = loaderContext._compilation.outputOptions;
 	if(content) {
 		// Match hash template
 		url = url
 			.replace(
 				/\[(?:([^:]+):)?hash(?::([a-z]+\d*))?(?::(\d+))?\]/ig,
-				(all, hashType, digestType, maxLength) => getHashDigest(content, hashType, digestType, parseInt(maxLength, 10))
+				(all, hashType, digestType, maxLength) => {
+					const resultHashType = hashType || compilationOutputOptions.hashFunction;
+					const resultDigestType = digestType || compilationOutputOptions.hashDigest;
+					const resultMaxLength = maxLength && parseInt(maxLength, 10) || compilationOutputOptions.hashDigestLength;
+					getHashDigest(content, resultHashType, resultDigestType, resultMaxLength);
+				}
 			)
 			.replace(
 				/\[emoji(?::(\d+))?\]/ig,

--- a/lib/interpolateName.js
+++ b/lib/interpolateName.js
@@ -64,7 +64,7 @@ function interpolateName(loaderContext, name, options) {
 		}
 	}
 	let url = filename;
-	const compilationOutputOptions = loaderContext._compilation.outputOptions;
+	const compilationOutputOptions = loaderContext._compilation && loaderContext._compilation.outputOptions || {};
 	if(content) {
 		// Match hash template
 		url = url
@@ -74,7 +74,7 @@ function interpolateName(loaderContext, name, options) {
 					const resultHashType = hashType || compilationOutputOptions.hashFunction;
 					const resultDigestType = digestType || compilationOutputOptions.hashDigest;
 					const resultMaxLength = maxLength && parseInt(maxLength, 10) || compilationOutputOptions.hashDigestLength;
-					getHashDigest(content, resultHashType, resultDigestType, resultMaxLength);
+					return getHashDigest(content, resultHashType, resultDigestType, resultMaxLength);
 				}
 			)
 			.replace(

--- a/test/interpolateName.test.js
+++ b/test/interpolateName.test.js
@@ -23,17 +23,22 @@ describe("interpolateName()", () => {
 	}
 
 	[
-		["/app/js/javascript.js", "js/[hash].script.[ext]", "test content", "js/9473fdd0d880a43c21b7778d34872157.script.js"],
-		["/app/page.html", "html-[hash:6].html", "test content", "html-9473fd.html"],
-		["/app/flash.txt", "[hash]", "test content", "9473fdd0d880a43c21b7778d34872157"],
-		["/app/img/image.png", "[sha512:hash:base64:7].[ext]", "test content", "2BKDTjl.png"],
-		["/app/dir/file.png", "[path][name].[ext]?[hash]", "test content", "/app/dir/file.png?9473fdd0d880a43c21b7778d34872157"],
-		["/vendor/test/images/loading.gif", path => path.replace(/\/?vendor\/?/, ""), "test content", "test/images/loading.gif"],
-		["/pathWith.period/filename.js", "js/[name].[ext]", "test content", "js/filename.js"],
-		["/pathWith.period/filenameWithoutExt", "js/[name].[ext]", "test content", "js/filenameWithoutExt.bin"]
+		[{ resourcePath: "/app/js/javascript.js" }, "js/[hash].script.[ext]", "test content", "js/9473fdd0d880a43c21b7778d34872157.script.js"],
+		[{ resourcePath: "/app/page.html" }, "html-[hash:6].html", "test content", "html-9473fd.html"],
+		[{ resourcePath: "/app/flash.txt" }, "[hash]", "test content", "9473fdd0d880a43c21b7778d34872157"],
+		[{ resourcePath: "/app/img/image.png" }, "[sha512:hash:base64:7].[ext]", "test content", "2BKDTjl.png"],
+		[{ resourcePath: "/app/img/image.png", _compilation: { outputOptions: {
+			hashFunction: "sha512",
+			hashDigest: "base64",
+			hashDigestLength: 7
+		} } }, "[sha512:hash:base64:7].[ext]", "test content", "2BKDTjl.png"],
+		[{ resourcePath: "/app/dir/file.png" }, "[path][name].[ext]?[hash]", "test content", "/app/dir/file.png?9473fdd0d880a43c21b7778d34872157"],
+		[{ resourcePath: "/vendor/test/images/loading.gif" }, path => path.replace(/\/?vendor\/?/, ""), "test content", "test/images/loading.gif"],
+		[{ resourcePath: "/pathWith.period/filename.js" }, "js/[name].[ext]", "test content", "js/filename.js"],
+		[{ resourcePath: "/pathWith.period/filenameWithoutExt" }, "js/[name].[ext]", "test content", "js/filenameWithoutExt.bin"]
 	].forEach(test => {
-		it("should interpolate " + test[0] + " " + test[1], () => {
-			const interpolatedName = loaderUtils.interpolateName({ resourcePath: test[0] }, test[1], { content: test[2] });
+		it("should interpolate " + test[0].resourcePath + " " + test[1], () => {
+			const interpolatedName = loaderUtils.interpolateName(test[0], test[1], { content: test[2] });
 			assert.equal(interpolatedName, test[3]);
 		});
 	});

--- a/test/interpolateName.test.js
+++ b/test/interpolateName.test.js
@@ -48,12 +48,12 @@ describe("interpolateName()", () => {
 			assert.throws(
 				() => {
 					const interpolatedName = loaderUtils.interpolateName(
-						{ }, "[" + hashName + ":hash:base64:10]", {content:"a"}
+						{ }, "[" + hashName + ":hash:base64:10]", { content: "a" }
 					);
 					// if for any reason the system we're running on has a hash
 					// algorithm matching any of our bogus names, at least make sure
 					// the output is not the unmodified name:
-					assert(interpolatedName[0] !== '[');
+					assert(interpolatedName[0] !== "[");
 				},
 				/digest method not supported/i
 			);


### PR DESCRIPTION
Good day, guys!

Yesterday I worked on configuring webpack for my own project and I found that I can't use the same output filename settings for all loaders. Especially, for file-loader.

Here is the part of  **webpack.config.js**:
```js
output: {
  path: outputPath,
  filename: '[name].[contenthash].js',
  publicPath: `${publicPath}/`,
  hashDigestLength: 8
},
module: {
  rules: [
    {
      test: /\.(png|jpg|gif|svg|cur)(\?v=\d+\.\d+.\d+)?$/,
      include: paths.src,
      use: [
        {
          loader: 'file-loader',
          options: {
            name: '[name].[hash].[ext]',
            publicPath: `${publicPath}/`
          }
        }
      ]
    }
  ]
},
plugins: [
  htmlWebpackPlugin,
  new MiniCssExtractPlugin({
    filename: '[name].[contenthash].css'
  })
]
```

After compilation I found that the hash part of name of extracted css and bundled files are truncated, but all other assets that I uploaded as is with file-loader are not truncated. As solution, I should pass `maxLength` to `options.name` (in format `[name].[hash:8].[ext]`) and it will work as I expected.
I think it is not good because I should pass the same settings for each loader, may be is better to support compiler settings as it support **MiniCssExtractPlugin**.

What you think about it?