### PR TITLE
fix: fix regexp replace for contenthash|hash fields in interpolateName

### DIFF
--- a/lib/interpolateName.js
+++ b/lib/interpolateName.js
@@ -91,7 +91,7 @@ function interpolateName(loaderContext, name, options) {
       // `hash` and `contenthash` are same in `loader-utils` context
       // let's keep `hash` for backward compatibility
       .replace(
-        /\[(?:([^:\]]+):)?(?:hash||contenthash)(?::([a-z]+\d*))?(?::(\d+))?\]/gi,
+        /\[(?:([^[:\]]+):)?(?:hash|contenthash)(?::([a-z]+\d*))?(?::(\d+))?]/gi,
         (all, hashType, digestType, maxLength) =>
           getHashDigest(content, hashType, digestType, parseInt(maxLength, 10))
       )


### PR DESCRIPTION
Double || breaks some specific cases, moreover this is pattern error https://regex101.com/r/ReFLZL/1