### PR TITLE
Use loaderContext.rootContext in webpack 4

### DIFF
--- a/lib/stringifyRequest.js
+++ b/lib/stringifyRequest.js
@@ -16,6 +16,7 @@ function stringifyRequest(loaderContext, request) {
   const splitted = request.split('!');
   const context =
     loaderContext.context ||
+    loaderContext.rootContext ||
     (loaderContext.options && loaderContext.options.context);
 
   return JSON.stringify(


### PR DESCRIPTION
According to https://github.com/webpack/loader-utils/pull/116#discussion_r243915939, I re-submitted this PR.