### PR TITLE
Support [query] in interpolateName

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ The following tokens are replaced in the `name` parameter:
 * `[name]` the basename of the resource
 * `[path]` the path of the resource relative to the `context` query parameter or option.
 * `[folder]` the folder the resource is in.
+* `[query]` the query parameters string without the leading `?`
 * `[emoji]` a random emoji representation of `options.content`
 * `[emoji:<length>]` same as above, but with a customizable number of emojis
 * `[contenthash]` the hash of `options.content` (Buffer) (by default it's the hex digest of the md5 hash)
@@ -212,6 +213,11 @@ loaderUtils.interpolateName(loaderContext, "html-[hash:6].html", { content: ... 
 loaderUtils.interpolateName(loaderContext, "[hash]", { content: ... });
 // => c31e9820c001c9c4a86bce33ce43b679
 
+// loaderContext.resourcePath = "/app/img/icon.svg"
+// loaderContext.resourceQuery = "?color=red&bgColor=blue"
+loaderUtils.interpolateName(loaderContext, "[name].[ext]?[query]", { content: ... });
+// => /app/img/icon.svg?color=red&bgColor=blue
+
 // loaderContext.resourcePath = "/app/img/image.gif"
 loaderUtils.interpolateName(loaderContext, "[emoji]", { content: ... });
 // => 👍
@@ -233,6 +239,11 @@ loaderUtils.interpolateName(loaderContext, "picture.png");
 // loaderContext.resourcePath = "/app/dir/file.png"
 loaderUtils.interpolateName(loaderContext, "[path][name].[ext]?[hash]", { content: ... });
 // => /app/dir/file.png?9473fdd0d880a43c21b7778d34872157
+
+// loaderContext.resourcePath = "/app/img/icon.png"
+// loaderContext.resourceQuery = "?color=red&bgColor=blue"
+loaderUtils.interpolateName(loaderContext, "[path][name].[ext]?[hash]&[query]", { content: ... });
+// => /app/img/icon.png?9473fdd0d880a43c21b7778d34872157&color=red&bgColor=blue
 
 // loaderContext.resourcePath = "/app/js/page-home.js"
 loaderUtils.interpolateName(loaderContext, "script-[1].[ext]", { regExp: "page-(.*)\\.js", content: ... });

--- a/lib/interpolateName.js
+++ b/lib/interpolateName.js
@@ -52,9 +52,11 @@ function interpolateName(loaderContext, name, options) {
   let basename = 'file';
   let directory = '';
   let folder = '';
-  const query = loaderContext.resourceQuery
-    ? loaderContext.resourceQuery.substr(1)
-    : '';
+  let query = '';
+  if (loaderContext.resourceQuery) {
+    // If query was passed, strip the leading '?' character
+    query = loaderContext.resourceQuery.substr(1);
+  }
 
   if (loaderContext.resourcePath) {
     const parsed = path.parse(loaderContext.resourcePath);

--- a/lib/interpolateName.js
+++ b/lib/interpolateName.js
@@ -52,6 +52,9 @@ function interpolateName(loaderContext, name, options) {
   let basename = 'file';
   let directory = '';
   let folder = '';
+  const query = loaderContext.resourceQuery
+    ? loaderContext.resourceQuery.substr(1)
+    : '';
 
   if (loaderContext.resourcePath) {
     const parsed = path.parse(loaderContext.resourcePath);
@@ -104,7 +107,8 @@ function interpolateName(loaderContext, name, options) {
     .replace(/\[ext\]/gi, () => ext)
     .replace(/\[name\]/gi, () => basename)
     .replace(/\[path\]/gi, () => directory)
-    .replace(/\[folder\]/gi, () => folder);
+    .replace(/\[folder\]/gi, () => folder)
+    .replace(/\[query\]/gi, () => query);
 
   if (regExp && loaderContext.resourcePath) {
     const match = loaderContext.resourcePath.match(new RegExp(regExp));

--- a/test/interpolateName.test.js
+++ b/test/interpolateName.test.js
@@ -131,10 +131,31 @@ describe('interpolateName()', () => {
       'test content',
       'modal.[md5::base64:20].css',
     ],
+    [
+      'images/icon.svg?color=#ff0000&bgColor=#0000ff',
+      '[name].[ext]?[query]',
+      'test content',
+      'icon.svg?color=#ff0000&bgColor=#00ff00',
+    ],
+    [
+      'images/icon.svg?color=#ff0000&bgColor=#0000ff',
+      '[name].[ext]?[hash]&[query]',
+      'test content',
+      'icon.svg?9473fdd0d880a43c21b7778d34872157&color=#ff0000&bgColor=#00ff00',
+    ],
   ].forEach((test) => {
     it('should interpolate ' + test[0] + ' ' + test[1], () => {
+      const resourcePathParts = test[0].split('?');
+      const resourcePath = resourcePathParts[0];
+      const resourceQuery = resourcePathParts[1]
+        ? `?${resourcePathParts[1]}`
+        : undefined;
+
       const interpolatedName = loaderUtils.interpolateName(
-        { resourcePath: test[0] },
+        {
+          resourcePath,
+          resourceQuery,
+        },
         test[1],
         { content: test[2] }
       );

--- a/test/interpolateName.test.js
+++ b/test/interpolateName.test.js
@@ -135,13 +135,13 @@ describe('interpolateName()', () => {
       'images/icon.svg?color=#ff0000&bgColor=#0000ff',
       '[name].[ext]?[query]',
       'test content',
-      'icon.svg?color=#ff0000&bgColor=#00ff00',
+      'icon.svg?color=#ff0000&bgColor=#0000ff',
     ],
     [
       'images/icon.svg?color=#ff0000&bgColor=#0000ff',
       '[name].[ext]?[hash]&[query]',
       'test content',
-      'icon.svg?9473fdd0d880a43c21b7778d34872157&color=#ff0000&bgColor=#00ff00',
+      'icon.svg?9473fdd0d880a43c21b7778d34872157&color=#ff0000&bgColor=#0000ff',
     ],
   ].forEach((test) => {
     it('should interpolate ' + test[0] + ' ' + test[1], () => {


### PR DESCRIPTION
This PR adds support for `[query]` in the template of `interpolateName`.

Some background: I want to load SVG files in CSS but pass query parameters to them to influence SVG properties such as `fill` etc. After some digging I found out that `file-loader` uses the `interpolateName` function in this lib, and that there's no way to use `[query]` in the template. Seemed to me like this would be nice to have and easy enough to support.

I'd love to get your feedback on this. Please let me know if there's anything I missed!