### PR TITLE
Default getOptions to return {}

### DIFF
--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -5,7 +5,12 @@ const parseQuery = require('./parseQuery');
 function getOptions(loaderContext) {
   const query = loaderContext.query;
 
-  if (typeof query === 'string' && query !== '') {
+  if (query === '') {
+    // webpack sets query to '' when no options are set
+    return {};
+  }
+
+  if (typeof query === 'string') {
     return parseQuery(loaderContext.query);
   }
 


### PR DESCRIPTION
Default getOptions to return {}, that way loaders don't break when the loader options are removed. For example, if the loader changes from "example-loader?setFlag" to "example-loader".

Without this change every single user of getOptions will almost certainly want to default getOptions to null manually.