### PR TITLE
Upgrade json5 to fix a vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "big.js": "^5.2.2",
     "emojis-list": "^3.0.0",
-    "json5": "^1.0.1"
+    "json5": "^2.1.2"
   },
   "scripts": {
     "lint": "eslint lib test",


### PR DESCRIPTION
json5 version less than 2.1.2 depends on minimalist version less than 1.2.2 that has this vulnerability https://app.snyk.io/vuln/SNYK-JS-MINIMIST-559764.

json5 2.1.2 [already fixed this](https://github.com/json5/json5/releases/tag/v2.1.2).