### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,27 @@ matrix:
     - node_js: '13'
       script: yarn test:ci
       env: CI=coverage 13
+# Adding power support architecture      
+    - arch: ppc64le
+      node_js: '12'
+      script: yarn pretest
+      env: CI=pretest
+    - arch: ppc64le
+      node_js: '8'
+      script: yarn test:ci
+      env: CI=tests 8
+    - arch: ppc64le
+      node_js: '10'
+      script: yarn test:ci
+      env: CI=tests 10
+    - arch: ppc64le
+      node_js: '12'
+      script: yarn test:ci
+      env: CI=coverage 12
+    - arch: ppc64le
+      node_js: '13'
+      script: yarn test:ci
+      env: CI=coverage 13
 
 before_install:
   - yarn install --ignore-engines


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.