### PR TITLE
fix: allow `interpolateName` works without options

### DIFF
--- a/lib/interpolateName.js
+++ b/lib/interpolateName.js
@@ -3,7 +3,7 @@
 const path = require("path");
 const getHashDigest = require("./getHashDigest");
 
-function interpolateName(loaderContext, name, options) {
+function interpolateName(loaderContext, name, options = {}) {
   let filename;
 
   const hasQuery =

--- a/test/interpolateName.test.js
+++ b/test/interpolateName.test.js
@@ -263,12 +263,11 @@ describe("interpolateName()", () => {
     ],
   ]);
 
-  it("should return the same emoji for the same string", () => {
-    const args = [{}, "[emoji:5]", { content: "same_emoji" }];
-    const result1 = loaderUtils.interpolateName.apply(loaderUtils, args);
-    const result2 = loaderUtils.interpolateName.apply(loaderUtils, args);
+  it("should work without options", () => {
+    const args = [{}, "foo/bar/[hash]"];
+    const result = loaderUtils.interpolateName.apply(loaderUtils, args);
 
-    expect(result1).toBe(result2);
+    expect(result).toBe("foo/bar/[hash]");
   });
 
   describe("no loader context", () => {


### PR DESCRIPTION
bugfix