### PR TITLE
base64url

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "pwa-node",
+			"request": "launch",
+			"name": "Launch Program",
+			"skipFiles": [
+				"<node_internals>/**"
+			],
+			"program": "${workspaceFolder}\\lib\\index.js"
+		}
+	]
+}

--- a/lib/getHashDigest.js
+++ b/lib/getHashDigest.js
@@ -8,7 +8,7 @@ const baseEncodeTables = {
   52: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
   58: "123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ", // no 0lIO
   62: "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
-  64: "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_",
+  "64url": "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_",
 };
 
 /**
@@ -33,8 +33,10 @@ function encodeBufferToBase(buffer, base, length) {
     throw new Error("Unknown encoding base" + base);
   }
 
+  const tableLength = encodeTable.length;
+
   // Input bits are only enough to generate this many characters
-  const limit = Math.ceil((buffer.length * 8) / Math.log2(base));
+  const limit = Math.ceil((buffer.length * 8) / Math.log2(tableLength));
   length = Math.min(length, limit);
 
   // Most of the crypto digests (if not all) has length a multiple of 4 bytes.
@@ -48,7 +50,7 @@ function encodeBufferToBase(buffer, base, length) {
   let output = "";
 
   for (let i = 0; i < length; i++) {
-    output = encodeTable[divmod32(uint32Array, base)] + output;
+    output = encodeTable[divmod32(uint32Array, tableLength)] + output;
   }
 
   return output;
@@ -120,7 +122,8 @@ function getHashDigest(buffer, algorithm, digestType, maxLength) {
     digestType === "base49" ||
     digestType === "base52" ||
     digestType === "base58" ||
-    digestType === "base62"
+    digestType === "base62" ||
+    digestType === "base64url"
   ) {
     return encodeBufferToBase(hash.digest(), digestType.substr(4), maxLength);
   } else {

--- a/test/getHashDigest.test.js
+++ b/test/getHashDigest.test.js
@@ -4,6 +4,8 @@ const loaderUtils = require("../");
 
 describe("getHashDigest()", () => {
   [
+    ["test string", "xxhash64", "base64url", undefined, "9yNNKdhM-bF"],
+
     ["test string", "xxhash64", "hex", undefined, "e9e2c351e3c6b198"],
     ["test string", "xxhash64", "base64", undefined, "6eLDUePGsZg="],
     ["test string", "xxhash64", "base52", undefined, "byfYGDmnmyUr"],


### PR DESCRIPTION
With this change, both base64 and base64url are supported.
Example:
`getHashDigest("test string", "xxhash64", "base64url", undefined) //shoudl return "9yNNKdhM-bF"`
and (from an existing test)
`getHashDigest("test string", "xxhash64", "base64", undefined) //shoudl return "6eLDUePGsZg="` 