### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/getHashDigest.js
+++ b/lib/getHashDigest.js
@@ -125,12 +125,12 @@ function getHashDigest(buffer, algorithm, digestType, maxLength) {
   ) {
     return encodeBufferToBase(
       hash.digest(),
-      digestType === "base64safe" ? 64 : digestType.substr(4),
+      digestType === "base64safe" ? 64 : digestType.slice(4),
       maxLength
     );
   }
 
-  return hash.digest(digestType || "hex").substr(0, maxLength);
+  return hash.digest(digestType || "hex").slice(0, maxLength);
 }
 
 module.exports = getHashDigest;

--- a/lib/interpolateName.js
+++ b/lib/interpolateName.js
@@ -33,7 +33,7 @@ function interpolateName(loaderContext, name, options = {}) {
     let resourcePath = loaderContext.resourcePath;
 
     if (parsed.ext) {
-      ext = parsed.ext.substr(1);
+      ext = parsed.ext.slice(1);
     }
 
     if (parsed.dir) {
@@ -46,7 +46,7 @@ function interpolateName(loaderContext, name, options = {}) {
         .relative(context, resourcePath + "_")
         .replace(/\\/g, "/")
         .replace(/\.\.(\/)?/g, "_$1");
-      directory = directory.substr(0, directory.length - 1);
+      directory = directory.slice(0, -1);
     } else {
       directory = resourcePath.replace(/\\/g, "/").replace(/\.\.(\/)?/g, "_$1");
     }
@@ -65,7 +65,7 @@ function interpolateName(loaderContext, name, options = {}) {
     const hashIdx = query.indexOf("#");
 
     if (hashIdx >= 0) {
-      query = query.substr(0, hashIdx);
+      query = query.slice(0, hashIdx);
     }
   }
 

--- a/test/interpolateName.test.js
+++ b/test/interpolateName.test.js
@@ -219,8 +219,8 @@ describe("interpolateName()", () => {
       const queryIdx = test[0].indexOf("?");
 
       if (queryIdx >= 0) {
-        resourcePath = test[0].substr(0, queryIdx);
-        resourceQuery = test[0].substr(queryIdx);
+        resourcePath = test[0].slice(0, queryIdx);
+        resourceQuery = test[0].slice(queryIdx);
       } else {
         resourcePath = test[0];
       }


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Breaking Changes

None

### Additional Info
