### PR TITLE
chore(.editorconfig): remove redundant configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,10 +7,3 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
-
-[test/cases/parsing/bom/bomfile.{css,js}]
-charset = utf-8-bom
-
-[*.md]
-insert_final_newline = true
-trim_trailing_whitespace = false


### PR DESCRIPTION
1. No any files can match `[test/cases/parsing/bom/bomfile.{css,js}]` rule, so I remove it.
2. About `[*.md]`, the first rule `insert_final_newline = true` is repeated as above, the second `trim_trailing_whitespace = false`, I didn't find the point of applying it, so I removed the entire rule.