### PR TITLE
Modify Regex to avoid ReDoS

### DIFF
--- a/lib/interpolateName.js
+++ b/lib/interpolateName.js
@@ -76,7 +76,7 @@ function interpolateName(loaderContext, name, options = {}) {
       // `hash` and `contenthash` are same in `loader-utils` context
       // let's keep `hash` for backward compatibility
       .replace(
-        /\[(?:([^:\]]+):)?(?:hash|contenthash)(?::([a-z]+\d*))?(?::(\d+))?\]/gi,
+        /\[(?:([^\[:\]]+):)?(?:hash|contenthash)(?::([a-z]+\d*))?(?::(\d+))?\]/gi,
         (all, hashType, digestType, maxLength) =>
           getHashDigest(content, hashType, digestType, parseInt(maxLength, 10))
       );


### PR DESCRIPTION
As described in https://github.com/webpack/loader-utils/issues/216#issuecomment-1310995046, this is offered as a potential fix for the security vulnerability identified in the interpolateName.js method.  I used this online ReDoS checker: https://devina.io/redos-checker

The interpolateName.js tests pass with this change, but I'm not familiar enough with the code to be sure this wouldn't introduce problems for some valid inputs.

I'm submitting PRs for all three branches because our projects need versions 2.x and 1.x (loader-utils is a transitive dependency in multiple packages).