### PR TITLE
Feature: add digestType 'base64-safe'

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,16 +76,18 @@ The following tokens are replaced in the `name` parameter:
 - `[contenthash]` the hash of `options.content` (Buffer) (by default it's the hex digest of the `xxhash64` hash)
 - `[<hashType>:contenthash:<digestType>:<length>]` optionally one can configure
   - other `hashType`s, i. e. `xxhash64`, `sha1`, `md4` (wasm version), `native-md4` (`crypto` module version), `md5`, `sha256`, `sha512`
-  - other `digestType`s, i. e. `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`
+  - other `digestType`s, i. e. `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`, `base64-safe`
   - and `length` the length in chars
 - `[hash]` the hash of `options.content` (Buffer) (by default it's the hex digest of the `xxhash64` hash)
 - `[<hashType>:hash:<digestType>:<length>]` optionally one can configure
   - other `hashType`s, i. e. `xxhash64`, `sha1`, `md4` (wasm version), `native-md4` (`crypto` module version), `md5`, `sha256`, `sha512`
-  - other `digestType`s, i. e. `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`
+  - other `digestType`s, i. e. `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`, `base64-safe`
   - and `length` the length in chars
 - `[N]` the N-th match obtained from matching the current file name against `options.regExp`
 
 In loader context `[hash]` and `[contenthash]` are the same, but we recommend using `[contenthash]` for avoid misleading.
+
+`digestType` with `base64-safe` don't contain `/`, `+` and `=` symbols.
 
 Examples
 
@@ -157,7 +159,7 @@ const digestString = loaderUtils.getHashDigest(
 
 - `buffer` the content that should be hashed
 - `hashType` one of `xxhash64`, `sha1`, `md4`, `md5`, `sha256`, `sha512` or any other node.js supported hash type
-- `digestType` one of `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`
+- `digestType` one of `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`, `base64-safe`
 - `maxLength` the maximum length in chars
 
 ## License

--- a/README.md
+++ b/README.md
@@ -76,18 +76,18 @@ The following tokens are replaced in the `name` parameter:
 - `[contenthash]` the hash of `options.content` (Buffer) (by default it's the hex digest of the `xxhash64` hash)
 - `[<hashType>:contenthash:<digestType>:<length>]` optionally one can configure
   - other `hashType`s, i. e. `xxhash64`, `sha1`, `md4` (wasm version), `native-md4` (`crypto` module version), `md5`, `sha256`, `sha512`
-  - other `digestType`s, i. e. `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`, `base64-safe`
+  - other `digestType`s, i. e. `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`, `base64safe`
   - and `length` the length in chars
 - `[hash]` the hash of `options.content` (Buffer) (by default it's the hex digest of the `xxhash64` hash)
 - `[<hashType>:hash:<digestType>:<length>]` optionally one can configure
   - other `hashType`s, i. e. `xxhash64`, `sha1`, `md4` (wasm version), `native-md4` (`crypto` module version), `md5`, `sha256`, `sha512`
-  - other `digestType`s, i. e. `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`, `base64-safe`
+  - other `digestType`s, i. e. `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`, `base64safe`
   - and `length` the length in chars
 - `[N]` the N-th match obtained from matching the current file name against `options.regExp`
 
 In loader context `[hash]` and `[contenthash]` are the same, but we recommend using `[contenthash]` for avoid misleading.
 
-`digestType` with `base64-safe` don't contain `/`, `+` and `=` symbols.
+`digestType` with `base64safe` don't contain `/`, `+` and `=` symbols.
 
 Examples
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ const digestString = loaderUtils.getHashDigest(
 
 - `buffer` the content that should be hashed
 - `hashType` one of `xxhash64`, `sha1`, `md4`, `md5`, `sha256`, `sha512` or any other node.js supported hash type
-- `digestType` one of `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`, `base64-safe`
+- `digestType` one of `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`, `base64safe`
 - `maxLength` the maximum length in chars
 
 ## License

--- a/lib/getHashDigest.js
+++ b/lib/getHashDigest.js
@@ -64,10 +64,10 @@ function getHashDigest(buffer, algorithm, digestType, maxLength) {
   algorithm = algorithm || "xxhash64";
   maxLength = maxLength || 9999;
 
-  const makeSafe = digestType && digestType.endsWith('-safe');
+  const makeSafe = digestType && digestType.endsWith("-safe");
   if (makeSafe) {
     // remove '-safe' from 'digestType'
-    digestType = digestType.slice(0, -5)
+    digestType = digestType.slice(0, -5);
   }
 
   let hash;
@@ -130,11 +130,14 @@ function getHashDigest(buffer, algorithm, digestType, maxLength) {
   ) {
     return encodeBufferToBase(hash.digest(), digestType.substr(4), maxLength);
   } else {
-    let hashResult = hash.digest(digestType || 'hex').substr(0, maxLength);
+    const hashResult = hash.digest(digestType || "hex").substr(0, maxLength);
     if (makeSafe) {
-      return hashResult.replaceAll('/', '_').replaceAll('+', '-').replaceAll('=', '')
+      return hashResult
+        .replaceAll("/", "_")
+        .replaceAll("+", "-")
+        .replaceAll("=", "");
     }
-    return hashResult
+    return hashResult;
   }
 }
 

--- a/lib/getHashDigest.js
+++ b/lib/getHashDigest.js
@@ -64,12 +64,6 @@ function getHashDigest(buffer, algorithm, digestType, maxLength) {
   algorithm = algorithm || "xxhash64";
   maxLength = maxLength || 9999;
 
-  const makeSafe = digestType && digestType.endsWith("-safe");
-  if (makeSafe) {
-    // remove '-safe' from 'digestType'
-    digestType = digestType.slice(0, -5);
-  }
-
   let hash;
 
   if (algorithm === "xxhash64") {
@@ -126,19 +120,13 @@ function getHashDigest(buffer, algorithm, digestType, maxLength) {
     digestType === "base49" ||
     digestType === "base52" ||
     digestType === "base58" ||
-    digestType === "base62"
+    digestType === "base62" ||
+    digestType === "base64safe"
   ) {
     return encodeBufferToBase(hash.digest(), digestType.substr(4), maxLength);
-  } else {
-    const hashResult = hash.digest(digestType || "hex").substr(0, maxLength);
-    if (makeSafe) {
-      return hashResult
-        .replace(/\//g, "_")
-        .replace(/\+/g, "-")
-        .replace(/=/g, "");
-    }
-    return hashResult;
   }
+
+  return hash.digest(digestType || "hex").substr(0, maxLength);
 }
 
 module.exports = getHashDigest;

--- a/lib/getHashDigest.js
+++ b/lib/getHashDigest.js
@@ -64,6 +64,12 @@ function getHashDigest(buffer, algorithm, digestType, maxLength) {
   algorithm = algorithm || "xxhash64";
   maxLength = maxLength || 9999;
 
+  const makeSafe = digestType && digestType.endsWith('-safe');
+  if (makeSafe) {
+    // remove '-safe' from 'digestType'
+    digestType = digestType.slice(0, -5)
+  }
+
   let hash;
 
   if (algorithm === "xxhash64") {
@@ -124,7 +130,11 @@ function getHashDigest(buffer, algorithm, digestType, maxLength) {
   ) {
     return encodeBufferToBase(hash.digest(), digestType.substr(4), maxLength);
   } else {
-    return hash.digest(digestType || "hex").substr(0, maxLength);
+    let hashResult = hash.digest(digestType || 'hex').substr(0, maxLength);
+    if (makeSafe) {
+      return hashResult.replaceAll('/', '_').replaceAll('+', '-').replaceAll('=', '')
+    }
+    return hashResult
   }
 }
 

--- a/lib/getHashDigest.js
+++ b/lib/getHashDigest.js
@@ -123,7 +123,11 @@ function getHashDigest(buffer, algorithm, digestType, maxLength) {
     digestType === "base62" ||
     digestType === "base64safe"
   ) {
-    return encodeBufferToBase(hash.digest(), digestType.substr(4), maxLength);
+    return encodeBufferToBase(
+      hash.digest(),
+      digestType === "base64safe" ? 64 : digestType.substr(4),
+      maxLength
+    );
   }
 
   return hash.digest(digestType || "hex").substr(0, maxLength);

--- a/lib/getHashDigest.js
+++ b/lib/getHashDigest.js
@@ -133,9 +133,9 @@ function getHashDigest(buffer, algorithm, digestType, maxLength) {
     const hashResult = hash.digest(digestType || "hex").substr(0, maxLength);
     if (makeSafe) {
       return hashResult
-        .replaceAll("/", "_")
-        .replaceAll("+", "-")
-        .replaceAll("=", "");
+        .replace(/\//g, "_")
+        .replace(/\+/g, "-")
+        .replace(/=/g, "");
     }
     return hashResult;
   }

--- a/lib/interpolateName.js
+++ b/lib/interpolateName.js
@@ -77,7 +77,7 @@ function interpolateName(loaderContext, name, options = {}) {
       // `hash` and `contenthash` are same in `loader-utils` context
       // let's keep `hash` for backward compatibility
       .replace(
-        /\[(?:([^[:\]]+):)?(?:hash|contenthash)(?::([a-z]+\d*))?(?::(\d+))?\]/gi,
+        /\[(?:([^[:\]]+):)?(?:hash|contenthash)(?::([a-z]+\d*(?:-safe)?))?(?::(\d+))?\]/gi,
         (all, hashType, digestType, maxLength) =>
           getHashDigest(content, hashType, digestType, parseInt(maxLength, 10))
       );

--- a/lib/interpolateName.js
+++ b/lib/interpolateName.js
@@ -77,7 +77,7 @@ function interpolateName(loaderContext, name, options = {}) {
       // `hash` and `contenthash` are same in `loader-utils` context
       // let's keep `hash` for backward compatibility
       .replace(
-        /\[(?:([^[:\]]+):)?(?:hash|contenthash)(?::([a-z]+\d*(?:-safe)?))?(?::(\d+))?\]/gi,
+        /\[(?:([^[:\]]+):)?(?:hash|contenthash)(?::([a-z]+\d*))?(?::(\d+))?\]/gi,
         (all, hashType, digestType, maxLength) =>
           getHashDigest(content, hashType, digestType, parseInt(maxLength, 10))
       );

--- a/test/getHashDigest.test.js
+++ b/test/getHashDigest.test.js
@@ -21,7 +21,7 @@ describe("getHashDigest()", () => {
     ["abc\\0💩", "md4", "hex", undefined, "45aa5b332f8e562aaf0106ad6fc1d78f"],
     ["abc\\0💩", "md4", "base64", undefined, "RapbMy+OViqvAQatb8HXjw=="],
     ["abc\\0♥", "md4", "base64", undefined, "Rrlif+z0m4Dq8BwB2Grp/Q=="],
-    ["abc\\0♥", "md4", "base64-safe", undefined, "Rrlif-z0m4Dq8BwB2Grp_Q"],
+    ["abc\\0♥", "md4", "base64safe", undefined, "Rrlif-z0m4Dq8BwB2Grp_Q"],
     ["abc\\0💩", "md4", "base52", undefined, "dtXZENFEkYHXGxOkJbevPoD"],
     ["abc\\0♥", "md4", "base52", undefined, "fYFFcfXRGsVweukHKlPayHs"],
 

--- a/test/getHashDigest.test.js
+++ b/test/getHashDigest.test.js
@@ -21,6 +21,7 @@ describe("getHashDigest()", () => {
     ["abc\\0💩", "md4", "hex", undefined, "45aa5b332f8e562aaf0106ad6fc1d78f"],
     ["abc\\0💩", "md4", "base64", undefined, "RapbMy+OViqvAQatb8HXjw=="],
     ["abc\\0♥", "md4", "base64", undefined, "Rrlif+z0m4Dq8BwB2Grp/Q=="],
+    ["abc\\0♥", "md4", "base64-safe", undefined, "Rrlif-z0m4Dq8BwB2Grp_Q"],
     ["abc\\0💩", "md4", "base52", undefined, "dtXZENFEkYHXGxOkJbevPoD"],
     ["abc\\0♥", "md4", "base52", undefined, "fYFFcfXRGsVweukHKlPayHs"],
 
@@ -78,6 +79,13 @@ describe("getHashDigest()", () => {
         expect(hashDigest).toBe(test[4]);
       }
     );
+
+    // it('for', () => {
+    //   for(let i = 0; i < 100; i += 1) {
+    //     const result = loaderUtils.getHashDigest(`a-${i}`, "xxhash64", "base64")
+    //     expect(result).toMatch(/^[a-zA-Z_][a-zA-Z\d-_]*$/g);
+    //   }
+    // })
   });
 });
 

--- a/test/getHashDigest.test.js
+++ b/test/getHashDigest.test.js
@@ -79,13 +79,6 @@ describe("getHashDigest()", () => {
         expect(hashDigest).toBe(test[4]);
       }
     );
-
-    // it('for', () => {
-    //   for(let i = 0; i < 100; i += 1) {
-    //     const result = loaderUtils.getHashDigest(`a-${i}`, "xxhash64", "base64")
-    //     expect(result).toMatch(/^[a-zA-Z_][a-zA-Z\d-_]*$/g);
-    //   }
-    // })
   });
 });
 

--- a/test/getHashDigest.test.js
+++ b/test/getHashDigest.test.js
@@ -21,7 +21,7 @@ describe("getHashDigest()", () => {
     ["abc\\0💩", "md4", "hex", undefined, "45aa5b332f8e562aaf0106ad6fc1d78f"],
     ["abc\\0💩", "md4", "base64", undefined, "RapbMy+OViqvAQatb8HXjw=="],
     ["abc\\0♥", "md4", "base64", undefined, "Rrlif+z0m4Dq8BwB2Grp/Q=="],
-    ["abc\\0♥", "md4", "base64safe", undefined, "Rrlif-z0m4Dq8BwB2Grp_Q"],
+    ["abc\\0♥", "md4", "base64safe", undefined, "3ZWmHo0hPMWE2rZeN_oHB6"],
     ["abc\\0💩", "md4", "base52", undefined, "dtXZENFEkYHXGxOkJbevPoD"],
     ["abc\\0♥", "md4", "base52", undefined, "fYFFcfXRGsVweukHKlPayHs"],
 


### PR DESCRIPTION
### This PR contains a:

- [ ]  bugfix
- [x]  new feature
- [ ]  code refactor
- [x]  test update
- [ ]  typo fix
- [ ]  metadata update

### Motivation / Use-Case
To simplify migration from v2 and getting "clean" css classnames, `digestType` with `base64-safe` don't contain `/`, `+` and `=` symbols.

### Breaking Changes
No